### PR TITLE
feat: agregar validación de variables de entorno con zod e interceptor de respuesta 401

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "react": "19.2.4",
     "react-dom": "19.2.4",
     "react-hook-form": "^7.72.1",
+    "zod": "^4.3.6",
     "zustand": "^5.0.12"
   },
   "lint-staged": {

--- a/src/lib/api/instance.ts
+++ b/src/lib/api/instance.ts
@@ -1,8 +1,9 @@
 import axios, { AxiosError, AxiosInstance, AxiosResponse, InternalAxiosRequestConfig } from 'axios';
+import { env } from '@lib/env';
 import type { ApiError, ApiFailure, ApiResult, ApiSuccess } from './types';
 
 const apiInstance: AxiosInstance = axios.create({
-  baseURL: process.env.NEXT_PUBLIC_API_URL,
+  baseURL: env.NEXT_PUBLIC_API_URL,
   timeout: 15_000,
   headers: {
     'Content-Type': 'application/json',
@@ -20,6 +21,19 @@ apiInstance.interceptors.request.use(
     return config;
   },
   (error: AxiosError) => Promise.reject(error),
+);
+
+apiInstance.interceptors.response.use(
+  (response: AxiosResponse) => response,
+  (error: AxiosError) => {
+    if (error.response?.status === 401) {
+      if (typeof window !== 'undefined') {
+        localStorage.removeItem('token');
+        window.location.href = '/';
+      }
+    }
+    return Promise.reject(error);
+  },
 );
 
 const toSuccess = <T>(response: AxiosResponse<T>): ApiSuccess<T> => ({

--- a/src/lib/env.ts
+++ b/src/lib/env.ts
@@ -1,0 +1,9 @@
+import { z } from 'zod';
+
+const envSchema = z.object({
+  NEXT_PUBLIC_API_URL: z.string().url('NEXT_PUBLIC_API_URL debe ser una URL válida'),
+});
+
+export const env = envSchema.parse({
+  NEXT_PUBLIC_API_URL: process.env.NEXT_PUBLIC_API_URL,
+});


### PR DESCRIPTION
- Crear src/lib/env.ts para validar NEXT_PUBLIC_API_URL con zod al iniciar la app
- Reemplazar uso directo de process.env en la instancia de axios por el objeto env validado
- Agregar interceptor de respuesta para errores 401: limpia el token de localStorage y redirige al home hasta que exista una ruta de login definida