### PR TITLE
refactor(notifications): harden type safety and fix lifecycle bugs

### DIFF
--- a/src/shared/components/organisms/ModalHost.tsx
+++ b/src/shared/components/organisms/ModalHost.tsx
@@ -47,7 +47,7 @@ const ModalHost = () => {
             }}
             color="inherit"
           >
-            {tFn(cancel.labelKey)}
+            {resolveNotificationText(tFn, cancel.labelKey, cancel.label) || tFn('common.cancel')}
           </Button>
           <Button
             onClick={() => {
@@ -57,7 +57,7 @@ const ModalHost = () => {
             variant="contained"
             color="primary"
           >
-            {tFn(confirm.labelKey)}
+            {resolveNotificationText(tFn, confirm.labelKey, confirm.label) || tFn('common.confirm')}
           </Button>
         </>
       );
@@ -74,7 +74,7 @@ const ModalHost = () => {
           variant="contained"
           color="primary"
         >
-          {tFn(action.labelKey)}
+          {resolveNotificationText(tFn, action.labelKey, action.label) || tFn('common.confirm')}
         </Button>
       );
     }

--- a/src/shared/components/organisms/ToastHost.tsx
+++ b/src/shared/components/organisms/ToastHost.tsx
@@ -15,10 +15,10 @@ import { resolveNotificationText } from '@shared/notifications/utils';
 import { BOTTOM_NAV_HEIGHT } from '@shared/layouts/DrawerShell';
 
 const SEVERITY_DURATION: Record<ToastSeverity, number> = {
-  [ToastSeverity.SUCCESS]: 4000,
-  [ToastSeverity.INFO]: 4000,
-  [ToastSeverity.WARNING]: 5500,
-  [ToastSeverity.ERROR]: 7000,
+  [ToastSeverity.SUCCESS]: 2000,
+  [ToastSeverity.INFO]: 2000,
+  [ToastSeverity.WARNING]: 2750,
+  [ToastSeverity.ERROR]: 3500,
 };
 
 const SEVERITY_COLOR: Record<ToastSeverity, string> = {
@@ -36,9 +36,17 @@ const ToastItemEl = ({ toast, onDismiss }: { toast: ToastItem; onDismiss: () => 
   const [expanded, setExpanded] = useState(false);
   const [capturedHeight, setCapturedHeight] = useState<number | null>(null);
   const boxRef = useRef<HTMLDivElement>(null);
+  const dismissedRef = useRef(false);
+  const autoTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const timerIds = useRef<ReturnType<typeof setTimeout>[]>([]);
 
   const startDismiss = useCallback(() => {
+    if (dismissedRef.current) return;
+    dismissedRef.current = true;
+    if (autoTimerRef.current) {
+      clearTimeout(autoTimerRef.current);
+      autoTimerRef.current = null;
+    }
     if (boxRef.current) setCapturedHeight(boxRef.current.offsetHeight);
     setPhase('fading');
     timerIds.current.push(setTimeout(() => setPhase('collapsing'), 200));
@@ -49,27 +57,18 @@ const ToastItemEl = ({ toast, onDismiss }: { toast: ToastItem; onDismiss: () => 
   const severityColor = SEVERITY_COLOR[severity];
   const duration = toast.duration ?? SEVERITY_DURATION[severity];
 
-  const title = resolveNotificationText(
-    t as (k: string, v?: Record<string, string | number>) => string,
-    toast.titleKey,
-    toast.title,
-    toast.i18nValues,
-  );
-  const message = resolveNotificationText(
-    t as (k: string, v?: Record<string, string | number>) => string,
-    toast.messageKey,
-    toast.message,
-    toast.i18nValues,
-  );
+  const tFn = t as (k: string, v?: Record<string, string | number>) => string;
+  const title = resolveNotificationText(tFn, toast.titleKey, toast.title, toast.i18nValues);
+  const message = resolveNotificationText(tFn, toast.messageKey, toast.message, toast.i18nValues);
 
   const isLong = message.length > MAX_PREVIEW_CHARS;
   const preview = isLong ? `${message.slice(0, MAX_PREVIEW_CHARS).trimEnd()}…` : message;
   const remainder = isLong ? message.slice(MAX_PREVIEW_CHARS) : '';
 
   useEffect(() => {
-    const id = setTimeout(startDismiss, duration);
+    autoTimerRef.current = setTimeout(startDismiss, duration);
     return () => {
-      clearTimeout(id);
+      if (autoTimerRef.current) clearTimeout(autoTimerRef.current);
       timerIds.current.forEach(clearTimeout);
       timerIds.current = [];
     };

--- a/src/shared/notifications/types.ts
+++ b/src/shared/notifications/types.ts
@@ -18,10 +18,9 @@ export enum NotificationHorizontal {
   RIGHT = 'right',
 }
 
-export type NotificationAction = {
-  labelKey: string;
-  onClick: () => void;
-};
+export type NotificationAction =
+  | { labelKey: string; label?: string; onClick: () => void }
+  | { label: string; labelKey?: string; onClick: () => void };
 
 type NotificationBase = {
   /** i18n key resolved via useTranslations. Takes priority over `message`. */


### PR DESCRIPTION
## Summary

- Replaces flat `NotificationConfig` with `ToastConfig | ModalConfig`
  discriminated union — invalid cross-type field combos are now
  compile errors
- Fixes toast double-dismiss race (auto-timer + manual close) and
  timer leak on unmount via ref-tracked cleanup
- Fixes stale modal config after close via two-phase Zustand clear
- `NotificationAction` requires at least one of `labelKey` / `label`;
  ModalHost auto-falls back to `common.confirm` / `common.cancel`
- Strategy instances moved from module scope into `useMemo` per
  provider — safe under concurrent SSR requests

## Test plan

- [ ] Toast auto-dismisses at new durations (SUCCESS 2s, ERROR 3.5s)
- [ ] Clicking X while auto-timer pending closes exactly once, no flicker
- [ ] Modal opens, confirms, and cancels correctly
- [ ] Modal content clears after close animation (no stale title flash
      on re-open)
- [ ] `notify({ type: MODAL, actions: [{ onClick }] })` renders
      "Confirmar" fallback without crashing
- [ ] TS error on `{ type: TOAST, hasTwoButtons: true }` and on
      `{ onClick }` action without label