### PR TITLE
feat(groups): tabla de ranking con posición, nombre, puntos y partidos predichos

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -122,7 +122,12 @@
     "create": "Create group",
     "join": "Join",
     "invite": "Invite friends",
-    "members": "Members"
+    "members": "Members",
+    "standingsTitle": "Standings",
+    "standingsRefresh": "Refresh standings",
+    "colPlayer": "Player",
+    "colPoints": "Pts",
+    "colPredictedMatches": "Predicted"
   },
   "dashboard": {
     "title": "Control Panel",

--- a/messages/es.json
+++ b/messages/es.json
@@ -122,7 +122,12 @@
     "create": "Crear grupo",
     "join": "Unirse",
     "invite": "Invitar amigos",
-    "members": "Miembros"
+    "members": "Miembros",
+    "standingsTitle": "Clasificación",
+    "standingsRefresh": "Actualizar clasificación",
+    "colPlayer": "Jugador",
+    "colPoints": "Pts",
+    "colPredictedMatches": "Predichos"
   },
   "dashboard": {
     "title": "Panel de Control",

--- a/src/features/groups/components/organisms/GroupDetail.tsx
+++ b/src/features/groups/components/organisms/GroupDetail.tsx
@@ -30,7 +30,7 @@ interface GroupDetailProps {
 const GroupDetail = ({ groupId }: GroupDetailProps) => {
   const t = useTranslations('groups');
   const tCommon = useTranslations('common');
-  const { data, isLoading, error } = useGroupDetail(groupId);
+  const { data, isLoading, error, refetch } = useGroupDetail(groupId);
   const session = useAuthStore((s) => s.session);
   const [shareOpen, setShareOpen] = useState(false);
   const [successOpen, setSuccessOpen] = useState(() => {
@@ -116,7 +116,12 @@ const GroupDetail = ({ groupId }: GroupDetailProps) => {
           }}
         >
           <Box sx={{ display: 'flex', flexDirection: 'column', gap: 3 }}>
-            <StandingsTable standings={data.standings} currentUserId={currentUserId} />
+            <StandingsTable
+              standings={data.standings}
+              currentUserId={currentUserId}
+              onRefresh={refetch}
+              isRefreshing={isLoading}
+            />
             <MatchPredictionList matches={data.pendingMatches} />
           </Box>
 

--- a/src/features/groups/components/organisms/StandingsTable.tsx
+++ b/src/features/groups/components/organisms/StandingsTable.tsx
@@ -2,9 +2,12 @@
 
 import Avatar from '@mui/material/Avatar';
 import Box from '@mui/material/Box';
+import IconButton from '@mui/material/IconButton';
+import Tooltip from '@mui/material/Tooltip';
 import Typography from '@mui/material/Typography';
 import useMediaQuery from '@mui/material/useMediaQuery';
 import LeaderboardOutlinedIcon from '@mui/icons-material/LeaderboardOutlined';
+import RefreshIcon from '@mui/icons-material/Refresh';
 import { useTranslations } from 'next-intl';
 import { tokens } from '@lib/theme/theme';
 import { getInitials } from '@shared/utils/string';
@@ -13,23 +16,25 @@ import type { StandingRow } from '../../types';
 interface StandingsTableProps {
   standings: StandingRow[];
   currentUserId: string;
+  onRefresh?: () => void;
+  isRefreshing?: boolean;
 }
 
-const StandingsTable = ({ standings, currentUserId }: StandingsTableProps) => {
+const StandingsTable = ({
+  standings,
+  currentUserId,
+  onRefresh,
+  isRefreshing = false,
+}: StandingsTableProps) => {
   const t = useTranslations('groups');
   const isDesktop = useMediaQuery('(min-width:900px)');
 
+  const sorted = [...standings].sort((a, b) => b.points - a.points);
+
   const headerColsMobile = ['#', t('colPlayer'), t('colPoints')];
-  const headerColsDesktop = [
-    '#',
-    t('colPlayer'),
-    t('colPoints'),
-    t('colWon'),
-    t('colDrawn'),
-    t('colLost'),
-  ];
+  const headerColsDesktop = ['#', t('colPlayer'), t('colPoints'), t('colPredictedMatches')];
   const cols = isDesktop ? headerColsDesktop : headerColsMobile;
-  const gridTemplate = isDesktop ? '32px 1fr 52px 36px 36px 36px' : '32px 1fr 52px';
+  const gridTemplate = isDesktop ? '32px 1fr 60px 80px' : '32px 1fr 52px';
 
   return (
     <Box
@@ -44,10 +49,39 @@ const StandingsTable = ({ standings, currentUserId }: StandingsTableProps) => {
         <LeaderboardOutlinedIcon sx={{ color: tokens.primary, fontSize: 20 }} />
         <Typography
           variant="h6"
-          sx={{ color: tokens.onSurface, textTransform: 'uppercase', letterSpacing: '0.04em' }}
+          sx={{
+            color: tokens.onSurface,
+            textTransform: 'uppercase',
+            letterSpacing: '0.04em',
+            flex: 1,
+          }}
         >
           {t('standingsTitle')}
         </Typography>
+
+        {onRefresh && (
+          <Tooltip title={t('standingsRefresh')}>
+            <span>
+              <IconButton
+                size="small"
+                onClick={onRefresh}
+                disabled={isRefreshing}
+                sx={{
+                  color: tokens.onSurfaceVariant,
+                  '&:hover': { color: tokens.primary },
+                  transition: 'transform 400ms ease',
+                  ...(isRefreshing && { animation: 'spin 0.8s linear infinite' }),
+                  '@keyframes spin': {
+                    from: { transform: 'rotate(0deg)' },
+                    to: { transform: 'rotate(360deg)' },
+                  },
+                }}
+              >
+                <RefreshIcon sx={{ fontSize: 18 }} />
+              </IconButton>
+            </span>
+          </Tooltip>
+        )}
       </Box>
 
       {/* Column headers */}
@@ -78,7 +112,7 @@ const StandingsTable = ({ standings, currentUserId }: StandingsTableProps) => {
         ))}
       </Box>
 
-      {standings.map((row, idx) => {
+      {sorted.map((row, idx) => {
         const isCurrentUser = row.userId === currentUserId;
         const isFirst = row.rank === 1;
 
@@ -166,43 +200,19 @@ const StandingsTable = ({ standings, currentUserId }: StandingsTableProps) => {
               {row.points}
             </Typography>
 
-            {/* W / D / L — desktop only */}
+            {/* Predicted matches — desktop only */}
             {isDesktop && (
-              <>
-                <Typography
-                  variant="body2"
-                  sx={{
-                    color: tokens.success,
-                    textAlign: 'center',
-                    fontWeight: 600,
-                    fontSize: '0.78rem',
-                  }}
-                >
-                  {row.won}
-                </Typography>
-                <Typography
-                  variant="body2"
-                  sx={{
-                    color: tokens.onSurfaceVariant,
-                    textAlign: 'center',
-                    fontWeight: 600,
-                    fontSize: '0.78rem',
-                  }}
-                >
-                  {row.drawn}
-                </Typography>
-                <Typography
-                  variant="body2"
-                  sx={{
-                    color: tokens.error,
-                    textAlign: 'center',
-                    fontWeight: 600,
-                    fontSize: '0.78rem',
-                  }}
-                >
-                  {row.lost}
-                </Typography>
-              </>
+              <Typography
+                variant="body2"
+                sx={{
+                  color: tokens.onSurfaceVariant,
+                  textAlign: 'center',
+                  fontWeight: 500,
+                  fontSize: '0.78rem',
+                }}
+              >
+                {row.predictedMatches}
+              </Typography>
             )}
           </Box>
         );

--- a/src/features/groups/hooks/useGroupDetail.ts
+++ b/src/features/groups/hooks/useGroupDetail.ts
@@ -14,11 +14,18 @@ const MOCK_DATA: GroupDetailData = {
     createdAt: new Date().toISOString(),
   },
   standings: [
-    { rank: 1, userId: 'mock-admin-id', name: 'Narboleda', points: 45, won: 9, drawn: 2, lost: 1 },
-    { rank: 2, userId: 'user-2', name: 'Ana López', points: 38, won: 7, drawn: 3, lost: 2 },
-    { rank: 3, userId: 'user-3', name: 'Carlos R.', points: 30, won: 6, drawn: 0, lost: 4 },
-    { rank: 4, userId: 'user-4', name: 'María S.', points: 22, won: 4, drawn: 2, lost: 5 },
-    { rank: 5, userId: 'user-5', name: 'Jorge M.', points: 18, won: 3, drawn: 1, lost: 6 },
+    { rank: 1, userId: 'mock-admin-id', name: 'Narboleda', points: 45, predictedMatches: 12 },
+    { rank: 2, userId: 'user-2', name: 'Ana López', points: 38, predictedMatches: 10 },
+    { rank: 3, userId: 'user-3', name: 'Carlos R.', points: 30, predictedMatches: 10 },
+    { rank: 4, userId: 'user-4', name: 'María S.', points: 22, predictedMatches: 11 },
+    { rank: 5, userId: 'user-5', name: 'Jorge M.', points: 18, predictedMatches: 9 },
+    { rank: 6, userId: 'user-6', name: 'Laura P.', points: 15, predictedMatches: 8 },
+    { rank: 7, userId: 'user-7', name: 'Sebastián V.', points: 12, predictedMatches: 7 },
+    { rank: 8, userId: 'user-8', name: 'Camila T.', points: 10, predictedMatches: 6 },
+    { rank: 9, userId: 'user-9', name: 'Andrés F.', points: 8, predictedMatches: 5 },
+    { rank: 10, userId: 'user-10', name: 'Valentina G.', points: 6, predictedMatches: 4 },
+    { rank: 11, userId: 'user-11', name: 'Diego H.', points: 4, predictedMatches: 3 },
+    { rank: 12, userId: 'user-12', name: 'Isabella R.', points: 2, predictedMatches: 2 },
   ],
   pendingMatches: [
     {
@@ -66,6 +73,13 @@ export const useGroupDetail = (groupId: string) => {
   const [data, setData] = useState<GroupDetailData | null>(null);
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const [refreshKey, setRefreshKey] = useState(0);
+
+  const refetch = () => {
+    setIsLoading(true);
+    setError(null);
+    setRefreshKey((k) => k + 1);
+  };
 
   useEffect(() => {
     const isMock = process.env.NEXT_PUBLIC_MOCK_GROUPS === 'true';
@@ -90,7 +104,7 @@ export const useGroupDetail = (groupId: string) => {
     };
 
     fetchData();
-  }, [groupId]);
+  }, [groupId, refreshKey]);
 
-  return { data, isLoading, error };
+  return { data, isLoading, error, refetch };
 };

--- a/src/features/groups/types/index.ts
+++ b/src/features/groups/types/index.ts
@@ -44,9 +44,7 @@ export interface StandingRow {
   userId: string;
   name: string;
   points: number;
-  won: number;
-  drawn: number;
-  lost: number;
+  predictedMatches: number;
 }
 
 export interface PendingMatch {

--- a/src/i18n/messages/en.json
+++ b/src/i18n/messages/en.json
@@ -295,6 +295,8 @@
     "showLess": "Show less",
     "colPlayer": "Player",
     "colPoints": "Pts",
+    "standingsRefresh": "Refresh standings",
+    "colPredictedMatches": "Predicted",
     "colWon": "W",
     "colDrawn": "D",
     "colLost": "L",

--- a/src/i18n/messages/es.json
+++ b/src/i18n/messages/es.json
@@ -295,6 +295,8 @@
     "showLess": "Ver menos",
     "colPlayer": "Jugador",
     "colPoints": "Pts",
+    "standingsRefresh": "Actualizar clasificación",
+    "colPredictedMatches": "Predichos",
     "colWon": "V",
     "colDrawn": "E",
     "colLost": "D",


### PR DESCRIPTION
    - Reemplaza columnas W/D/L por partidos predichos en StandingsTable
    - Muestra todos los miembros del grupo ordenados por puntos desc
    - Resalta al usuario logueado con borde y color primario
    - Agrega botón de refresh con animación y refetch en useGroupDetail
    - Expande mock data a 12 miembros con campo predictedMatches
    - Agrega claves i18n: standingsTitle, standingsRefresh, colPlayer, colPoints, colPredictedMatches