### PR TITLE
Feature/layout navegacion panel de adminitrador

### DIFF
--- a/src/app/(dashboard)/admin/page.tsx
+++ b/src/app/(dashboard)/admin/page.tsx
@@ -1,0 +1,10 @@
+import { RequireAdmin } from '@features/auth';
+import { AdminComingSoon } from '@features/admin';
+
+const AdminPage = () => (
+  <RequireAdmin>
+    <AdminComingSoon />
+  </RequireAdmin>
+);
+
+export default AdminPage;

--- a/src/app/(dashboard)/home/page.tsx
+++ b/src/app/(dashboard)/home/page.tsx
@@ -1,10 +1,22 @@
 'use client';
 
+import Box from '@mui/material/Box';
+import CircularProgress from '@mui/material/CircularProgress';
 import { DashboardHome, UserDashboardHome } from '@features/dashboard';
+import { useAuthSession } from '@features/auth';
 
-// TODO: Replace with real user role check from session/profile.
-const IS_ADMIN = false;
+const DashboardHomePage = () => {
+  const { hydrated, isAdmin } = useAuthSession();
 
-const DashboardHomePage = () => (IS_ADMIN ? <DashboardHome /> : <UserDashboardHome />);
+  if (!hydrated) {
+    return (
+      <Box sx={{ minHeight: '100vh', display: 'grid', placeItems: 'center' }}>
+        <CircularProgress />
+      </Box>
+    );
+  }
+
+  return isAdmin ? <DashboardHome /> : <UserDashboardHome />;
+};
 
 export default DashboardHomePage;

--- a/src/app/(dashboard)/matches/load-results/page.tsx
+++ b/src/app/(dashboard)/matches/load-results/page.tsx
@@ -1,5 +1,10 @@
-import { MatchResultSelectionPanel } from '@features/matches';
+import { RequireAdmin } from '@features/auth';
+import MatchResultSelectionPanel from '@features/matches/components/organisms/MatchResultSelectionPanel';
 
-const LoadResultsPage = () => <MatchResultSelectionPanel />;
+const LoadResultsPage = () => (
+  <RequireAdmin>
+    <MatchResultSelectionPanel />
+  </RequireAdmin>
+);
 
 export default LoadResultsPage;

--- a/src/app/(dashboard)/users/page.tsx
+++ b/src/app/(dashboard)/users/page.tsx
@@ -1,5 +1,10 @@
 import { UsersAdmin } from '@features/users';
+import { RequireAdmin } from '@features/auth';
 
-const UsersAdminPage = () => <UsersAdmin />;
+const UsersAdminPage = () => (
+  <RequireAdmin>
+    <UsersAdmin />
+  </RequireAdmin>
+);
 
 export default UsersAdminPage;

--- a/src/app/403/page.tsx
+++ b/src/app/403/page.tsx
@@ -3,43 +3,47 @@ import Button from '@mui/material/Button';
 import Typography from '@mui/material/Typography';
 import AppCard from '@shared/components/molecules/AppCard';
 import { tokens } from '@lib/theme/theme';
+import { useTranslations } from 'next-intl';
 
-const ForbiddenPage = () => (
-  <Box
-    sx={{
-      minHeight: '100vh',
-      display: 'grid',
-      placeItems: 'center',
-      px: 3,
-      py: 6,
-      bgcolor: tokens.background,
-    }}
-  >
-    <AppCard
-      variant="default"
+const ForbiddenPage = () => {
+  const t = useTranslations('forbidden');
+  return (
+    <Box
       sx={{
-        maxWidth: 520,
-        width: '100%',
-        p: 4,
-        textAlign: 'center',
+        minHeight: '100vh',
         display: 'grid',
-        gap: 2,
+        placeItems: 'center',
+        px: 3,
+        py: 6,
+        bgcolor: tokens.background,
       }}
     >
-      <Typography sx={{ fontSize: '2.5rem', fontWeight: 900, color: tokens.primary }}>
-        403
-      </Typography>
-      <Typography sx={{ fontSize: '1.25rem', fontWeight: 800, color: tokens.onSurface }}>
-        Acceso restringido
-      </Typography>
-      <Typography sx={{ color: tokens.onSurfaceVariant, lineHeight: 1.6 }}>
-        No tienes permisos para ver esta sección.
-      </Typography>
-      <Button href="/home" variant="contained">
-        Volver al inicio
-      </Button>
-    </AppCard>
-  </Box>
-);
+      <AppCard
+        variant="default"
+        sx={{
+          maxWidth: 520,
+          width: '100%',
+          p: 4,
+          textAlign: 'center',
+          display: 'grid',
+          gap: 2,
+        }}
+      >
+        <Typography sx={{ fontSize: '2.5rem', fontWeight: 900, color: tokens.primary }}>
+          {t('code')}
+        </Typography>
+        <Typography sx={{ fontSize: '1.25rem', fontWeight: 800, color: tokens.onSurface }}>
+          {t('title')}
+        </Typography>
+        <Typography sx={{ color: tokens.onSurfaceVariant, lineHeight: 1.6 }}>
+          {t('description')}
+        </Typography>
+        <Button href="/home" variant="contained">
+          {t('cta')}
+        </Button>
+      </AppCard>
+    </Box>
+  );
+};
 
 export default ForbiddenPage;

--- a/src/app/403/page.tsx
+++ b/src/app/403/page.tsx
@@ -1,0 +1,45 @@
+import Box from '@mui/material/Box';
+import Button from '@mui/material/Button';
+import Typography from '@mui/material/Typography';
+import AppCard from '@shared/components/molecules/AppCard';
+import { tokens } from '@lib/theme/theme';
+
+const ForbiddenPage = () => (
+  <Box
+    sx={{
+      minHeight: '100vh',
+      display: 'grid',
+      placeItems: 'center',
+      px: 3,
+      py: 6,
+      bgcolor: tokens.background,
+    }}
+  >
+    <AppCard
+      variant="default"
+      sx={{
+        maxWidth: 520,
+        width: '100%',
+        p: 4,
+        textAlign: 'center',
+        display: 'grid',
+        gap: 2,
+      }}
+    >
+      <Typography sx={{ fontSize: '2.5rem', fontWeight: 900, color: tokens.primary }}>
+        403
+      </Typography>
+      <Typography sx={{ fontSize: '1.25rem', fontWeight: 800, color: tokens.onSurface }}>
+        Acceso restringido
+      </Typography>
+      <Typography sx={{ color: tokens.onSurfaceVariant, lineHeight: 1.6 }}>
+        No tienes permisos para ver esta sección.
+      </Typography>
+      <Button href="/home" variant="contained">
+        Volver al inicio
+      </Button>
+    </AppCard>
+  </Box>
+);
+
+export default ForbiddenPage;

--- a/src/features/admin/components/organisms/AdminComingSoon.tsx
+++ b/src/features/admin/components/organisms/AdminComingSoon.tsx
@@ -4,35 +4,36 @@ import AppCard from '@shared/components/molecules/AppCard';
 import PageHeader from '@shared/components/molecules/PageHeader';
 import AdminPanelSettingsIcon from '@mui/icons-material/AdminPanelSettings';
 import { tokens } from '@lib/theme/theme';
+import { useTranslations } from 'next-intl';
 
-const AdminComingSoon = () => (
-  <Box sx={{ p: { xs: 3, md: 4 }, maxWidth: 1100, mx: 'auto' }}>
-    <PageHeader
-      title="Admin"
-      subtitle="En proceso"
-      icon={<AdminPanelSettingsIcon sx={{ color: tokens.primary, fontSize: '1rem' }} />}
-    />
+const AdminComingSoon = () => {
+  const t = useTranslations('admin');
+  return (
+    <Box sx={{ p: { xs: 3, md: 4 }, maxWidth: 1100, mx: 'auto' }}>
+      <PageHeader
+        title={t('title')}
+        subtitle={t('subtitle')}
+        icon={<AdminPanelSettingsIcon sx={{ color: tokens.primary, fontSize: '1rem' }} />}
+      />
 
-    <AppCard
-      variant="default"
-      sx={{
-        p: 4,
-        minHeight: 260,
-        display: 'grid',
-        placeItems: 'center',
-        textAlign: 'center',
-      }}
-    >
-      <Box sx={{ display: 'grid', gap: 1.25, justifyItems: 'center' }}>
-        <Typography sx={{ fontSize: '1.1rem', fontWeight: 800, color: tokens.onSurface }}>
-          En proceso
-        </Typography>
-        <Typography sx={{ maxWidth: 480, color: tokens.onSurfaceVariant, lineHeight: 1.6 }}>
-          Esta sección estará disponible para tareas administrativas más adelante.
-        </Typography>
-      </Box>
-    </AppCard>
-  </Box>
-);
+      <AppCard
+        variant="default"
+        sx={{
+          p: 4,
+          minHeight: 260,
+          display: 'grid',
+          placeItems: 'center',
+          textAlign: 'center',
+        }}
+      >
+        <Box sx={{ display: 'grid', gap: 1.25, justifyItems: 'center' }}>
+          <Typography sx={{ maxWidth: 480, color: tokens.onSurfaceVariant, lineHeight: 1.6 }}>
+            {t('workingMessage')}
+          </Typography>
+        </Box>
+      </AppCard>
+    </Box>
+  );
+};
 
 export default AdminComingSoon;

--- a/src/features/admin/components/organisms/AdminComingSoon.tsx
+++ b/src/features/admin/components/organisms/AdminComingSoon.tsx
@@ -1,0 +1,38 @@
+import Box from '@mui/material/Box';
+import Typography from '@mui/material/Typography';
+import AppCard from '@shared/components/molecules/AppCard';
+import PageHeader from '@shared/components/molecules/PageHeader';
+import AdminPanelSettingsIcon from '@mui/icons-material/AdminPanelSettings';
+import { tokens } from '@lib/theme/theme';
+
+const AdminComingSoon = () => (
+  <Box sx={{ p: { xs: 3, md: 4 }, maxWidth: 1100, mx: 'auto' }}>
+    <PageHeader
+      title="Admin"
+      subtitle="En proceso"
+      icon={<AdminPanelSettingsIcon sx={{ color: tokens.primary, fontSize: '1rem' }} />}
+    />
+
+    <AppCard
+      variant="default"
+      sx={{
+        p: 4,
+        minHeight: 260,
+        display: 'grid',
+        placeItems: 'center',
+        textAlign: 'center',
+      }}
+    >
+      <Box sx={{ display: 'grid', gap: 1.25, justifyItems: 'center' }}>
+        <Typography sx={{ fontSize: '1.1rem', fontWeight: 800, color: tokens.onSurface }}>
+          En proceso
+        </Typography>
+        <Typography sx={{ maxWidth: 480, color: tokens.onSurfaceVariant, lineHeight: 1.6 }}>
+          Esta sección estará disponible para tareas administrativas más adelante.
+        </Typography>
+      </Box>
+    </AppCard>
+  </Box>
+);
+
+export default AdminComingSoon;

--- a/src/features/admin/index.ts
+++ b/src/features/admin/index.ts
@@ -1,0 +1,1 @@
+export { default as AdminComingSoon } from './components/organisms/AdminComingSoon';

--- a/src/features/auth/components/molecules/AuthGatewayHeader.tsx
+++ b/src/features/auth/components/molecules/AuthGatewayHeader.tsx
@@ -1,0 +1,106 @@
+'use client';
+
+import Box from '@mui/material/Box';
+import Typography from '@mui/material/Typography';
+import SportsSoccerIcon from '@mui/icons-material/SportsSoccer';
+import { tokens } from '@lib/theme/theme';
+
+interface AuthGatewayHeaderProps {
+  title: string;
+  subtitle: string;
+}
+
+const AuthGatewayHeader = ({ title, subtitle }: AuthGatewayHeaderProps) => (
+  <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1 }}>
+    <Typography
+      variant="h4"
+      align="center"
+      sx={{
+        fontSize: '1.5rem',
+        fontWeight: 900,
+        letterSpacing: '-0.04em',
+        color: tokens.primary,
+        textTransform: 'uppercase',
+      }}
+    >
+      {title}
+    </Typography>
+    <Box
+      sx={{
+        position: 'relative',
+        top: 0,
+        left: 'calc(50% - 16px)',
+        '@keyframes ballRoll': {
+          '0%': { transform: 'translateX(0)', opacity: 0 },
+          '5%': { transform: 'translateX(0)', opacity: 1 },
+          '62%': { transform: 'translateX(0)', opacity: 1 },
+          '80%': { transform: 'translateX(260px)', opacity: 0 },
+          '100%': { transform: 'translateX(0)', opacity: 0 },
+        },
+        animation: 'ballRoll 5s ease-in infinite',
+      }}
+    >
+      <SportsSoccerIcon
+        sx={{
+          color: tokens.primary,
+          fontSize: '2rem',
+          display: 'block',
+          '@keyframes ballBounce': {
+            '0%': {
+              transform: 'translateY(-260px) rotate(0deg)',
+              animationTimingFunction: 'ease-in',
+            },
+            '18%': {
+              transform: 'translateY(2px) rotate(0deg) scaleY(0.72)',
+              animationTimingFunction: 'ease-out',
+            },
+            '22%': {
+              transform: 'translateY(0) rotate(0deg) scaleY(1)',
+              animationTimingFunction: 'ease-in',
+            },
+            '30%': {
+              transform: 'translateY(-70px) rotate(35deg)',
+              animationTimingFunction: 'ease-in',
+            },
+            '38%': {
+              transform: 'translateY(2px) rotate(62deg) scaleY(0.83)',
+              animationTimingFunction: 'ease-out',
+            },
+            '41%': {
+              transform: 'translateY(0) rotate(62deg) scaleY(1)',
+              animationTimingFunction: 'ease-in',
+            },
+            '47%': {
+              transform: 'translateY(-32px) rotate(88deg)',
+              animationTimingFunction: 'ease-in',
+            },
+            '53%': {
+              transform: 'translateY(2px) rotate(112deg) scaleY(0.9)',
+              animationTimingFunction: 'ease-out',
+            },
+            '55%': {
+              transform: 'translateY(0) rotate(112deg) scaleY(1)',
+              animationTimingFunction: 'ease-in',
+            },
+            '58%': {
+              transform: 'translateY(-10px) rotate(122deg)',
+              animationTimingFunction: 'ease-in',
+            },
+            '62%': {
+              transform: 'translateY(0) rotate(130deg)',
+              animationTimingFunction: 'linear',
+            },
+            '80%': { transform: 'translateY(0) rotate(580deg)' },
+            '100%': { transform: 'translateY(-260px) rotate(0deg)' },
+          },
+          animation: 'ballBounce 5s ease-out infinite',
+        }}
+      />
+    </Box>
+    <Typography align="center" sx={{ color: tokens.onSurfaceVariant }}>
+      {subtitle}
+    </Typography>
+  </Box>
+);
+
+export default AuthGatewayHeader;

--- a/src/features/auth/components/molecules/AuthGatewayModeTabs.tsx
+++ b/src/features/auth/components/molecules/AuthGatewayModeTabs.tsx
@@ -1,0 +1,28 @@
+'use client';
+
+import type { SyntheticEvent } from 'react';
+import Tab from '@mui/material/Tab';
+import Tabs from '@mui/material/Tabs';
+
+type Mode = 'login' | 'register';
+
+interface AuthGatewayModeTabsProps {
+  mode: Mode;
+  loginLabel: string;
+  registerLabel: string;
+  onChange: (_: SyntheticEvent, value: Mode) => void;
+}
+
+const AuthGatewayModeTabs = ({
+  mode,
+  loginLabel,
+  registerLabel,
+  onChange,
+}: AuthGatewayModeTabsProps) => (
+  <Tabs centered value={mode} onChange={onChange}>
+    <Tab label={loginLabel} value="login" />
+    <Tab label={registerLabel} value="register" />
+  </Tabs>
+);
+
+export default AuthGatewayModeTabs;

--- a/src/features/auth/components/organisms/AuthGateway.tsx
+++ b/src/features/auth/components/organisms/AuthGateway.tsx
@@ -1,192 +1,36 @@
 'use client';
 
-import { useCallback, useEffect, useMemo, useState } from 'react';
-import { useRouter } from 'next/navigation';
-import { useForm, type Resolver } from 'react-hook-form';
-import { zodResolver } from '@hookform/resolvers/zod';
-import { useTranslations } from 'next-intl';
-import { loginSchema, registerFormSchema } from '@features/auth/lib/schemas';
-import type { RegisterFormInput } from '@features/auth/lib/schemas';
 import Alert from '@mui/material/Alert';
 import Box from '@mui/material/Box';
 import Divider from '@mui/material/Divider';
 import Stack from '@mui/material/Stack';
-import Tab from '@mui/material/Tab';
-import Tabs from '@mui/material/Tabs';
-import Typography from '@mui/material/Typography';
 import GoogleIcon from '@mui/icons-material/Google';
 import AppButton from '@shared/components/atoms/AppButton';
-import FormField from '@shared/components/atoms/FormField';
 import AppCard from '@shared/components/molecules/AppCard';
 import { tokens } from '@lib/theme/theme';
-import { useAuthStore } from '@features/auth/store/useAuthStore';
-import SportsSoccerIcon from '@mui/icons-material/SportsSoccer';
 import FloatingParticles from '@shared/components/organisms/FloatingParticles';
-
-type Mode = 'login' | 'register';
-
-type AuthFormData = RegisterFormInput;
-
-type ErrorNode = Record<string, unknown>;
-
-const translateErrorTree = (
-  errors: ErrorNode | undefined,
-  translate: (key: string) => string,
-): ErrorNode => {
-  if (!errors) return {};
-  const out: ErrorNode = {};
-  for (const [key, value] of Object.entries(errors)) {
-    if (value && typeof value === 'object') {
-      const node = value as ErrorNode;
-      if (typeof node.message === 'string' && node.message) {
-        out[key] = { ...node, message: translate(node.message) };
-      } else {
-        out[key] = translateErrorTree(node, translate);
-      }
-    } else {
-      out[key] = value;
-    }
-  }
-  return out;
-};
-
-const EMPTY_FORM: AuthFormData = {
-  email: '',
-  password: '',
-  nickname: '',
-  confirmPassword: '',
-};
+import AuthGatewayHeader from '../molecules/AuthGatewayHeader';
+import AuthGatewayModeTabs from '../molecules/AuthGatewayModeTabs';
+import AuthGatewayForm from './AuthGatewayForm';
+import { useAuthGateway } from '../../hooks/useAuthGateway';
 
 const AuthGateway = () => {
-  const router = useRouter();
-  const t = useTranslations('auth');
-  const [mode, setMode] = useState<Mode>('login');
-  const [pendingMode, setPendingMode] = useState<Mode | null>(null);
-  const [exiting, setExiting] = useState(false);
-  const [entering, setEntering] = useState(false);
-  const [direction, setDirection] = useState<'forward' | 'backward'>('forward');
-  const [notice, setNotice] = useState<{ type: 'success' | 'error'; text: string } | null>(null);
-
-  const isTransitioning = exiting || entering;
-
-  const handleModeChange = (_: React.SyntheticEvent, value: Mode) => {
-    if (value === mode || isTransitioning) return;
-    setDirection(value === 'register' ? 'forward' : 'backward');
-    setPendingMode(value);
-    setExiting(true);
-  };
-
-  const handlePanelAnimationEnd = (event: React.AnimationEvent<HTMLDivElement>) => {
-    if (event.animationName === 'authPanelExit' && exiting && pendingMode) {
-      setMode(pendingMode);
-      setExiting(false);
-      setEntering(true);
-      return;
-    }
-    if (event.animationName === 'authPanelEnter' && entering) {
-      setEntering(false);
-      setPendingMode(null);
-    }
-  };
-
-  const registerWithEmail = useAuthStore((state) => state.registerWithEmail);
-  const loginWithEmail = useAuthStore((state) => state.loginWithEmail);
-  const loginWithGoogle = useAuthStore((state) => state.loginWithGoogle);
-
-  const tRoot = useTranslations();
-  const translateKey = useCallback(
-    (key?: string, fallback?: string) => (key ? tRoot(key) : (fallback ?? '')),
-    [tRoot],
-  );
-
-  const resolver = useMemo<Resolver<AuthFormData>>(() => {
-    const base = zodResolver(
-      mode === 'register' ? registerFormSchema : loginSchema,
-    ) as unknown as Resolver<AuthFormData>;
-
-    const wrapped: Resolver<AuthFormData> = async (values, context, options) => {
-      const result = await base(values, context, options);
-      return {
-        ...result,
-        errors: translateErrorTree(result.errors as ErrorNode, translateKey),
-      } as Awaited<ReturnType<Resolver<AuthFormData>>>;
-    };
-    return wrapped;
-  }, [mode, translateKey]);
-
   const {
-    handleSubmit,
+    mode,
+    phase,
+    notice,
     control,
-    formState: { isSubmitting },
-    setError,
-    reset,
-    clearErrors,
-  } = useForm<AuthFormData>({
-    defaultValues: EMPTY_FORM,
-    mode: 'onBlur',
-    reValidateMode: 'onChange',
-    resolver,
-  });
-
-  useEffect(() => {
-    clearErrors();
-  }, [mode, clearErrors]);
-
-  const submitLabel = useMemo(
-    () => (mode === 'login' ? t('loginCta') : t('registerCta')),
-    [mode, t],
-  );
-
-  const onSubmit = (values: AuthFormData) => {
-    setNotice(null);
-
-    const result =
-      mode === 'register'
-        ? registerWithEmail({
-            email: values.email,
-            password: values.password,
-            nickname: values.nickname,
-          })
-        : loginWithEmail({ email: values.email, password: values.password });
-
-    if (!result.ok) {
-      if (result.fieldErrors?.email) {
-        setError('email', { message: translateKey(result.fieldErrors.email) });
-      }
-      if (result.fieldErrors?.password) {
-        setError('password', { message: translateKey(result.fieldErrors.password) });
-      }
-      if (result.fieldErrors?.nickname) {
-        setError('nickname', { message: translateKey(result.fieldErrors.nickname) });
-      }
-      if (result.messageKey) {
-        setNotice({ type: 'error', text: translateKey(result.messageKey, t('genericError')) });
-      }
-      return;
-    }
-
-    setNotice({
-      type: 'success',
-      text: translateKey(result.messageKey, t('sessionCreated')),
-    });
-    reset();
-    router.replace('/home');
-  };
-
-  const handleGoogleLogin = () => {
-    const result = loginWithGoogle();
-
-    if (!result.ok) {
-      setNotice({ type: 'error', text: translateKey(result.messageKey, t('genericError')) });
-      return;
-    }
-
-    setNotice({
-      type: 'success',
-      text: translateKey(result.messageKey, t('sessionCreated')),
-    });
-    router.replace('/home');
-  };
+    isSubmitting,
+    isTransitioning,
+    direction,
+    submitLabel,
+    handleSubmit,
+    handleModeChange,
+    handlePanelAnimationEnd,
+    handleGoogleSubmit,
+    submit,
+    t,
+  } = useAuthGateway();
 
   return (
     <Box
@@ -247,252 +91,41 @@ const AuthGateway = () => {
             pb: { xs: 'calc(env(safe-area-inset-bottom, 0px) + 24px)', sm: 4 },
           }}
         >
-          <Stack spacing={1}>
-            <Typography
-              variant="h4"
-              align="center"
-              sx={{
-                fontSize: '1.5rem',
-                fontWeight: 900,
-                letterSpacing: '-0.04em',
-                color: tokens.primary,
-                textTransform: 'uppercase',
-              }}
-            >
-              {t('title')}
-            </Typography>
-            <Box
-              sx={{
-                position: 'relative',
-                top: 0,
-                left: 'calc(50% - 16px)',
-                '@keyframes ballRoll': {
-                  '0%': { transform: 'translateX(0)', opacity: 0 },
-                  '5%': { transform: 'translateX(0)', opacity: 1 },
-                  '62%': { transform: 'translateX(0)', opacity: 1 },
-                  '80%': { transform: 'translateX(260px)', opacity: 0 },
-                  '100%': { transform: 'translateX(0)', opacity: 0 },
-                },
-                animation: 'ballRoll 5s ease-in infinite',
-              }}
-            >
-              <SportsSoccerIcon
-                sx={{
-                  color: tokens.primary,
-                  fontSize: '2rem',
-                  display: 'block',
-                  '@keyframes ballBounce': {
-                    '0%': {
-                      transform: 'translateY(-260px) rotate(0deg)',
-                      animationTimingFunction: 'ease-in',
-                    },
-                    '18%': {
-                      transform: 'translateY(2px) rotate(0deg) scaleY(0.72)',
-                      animationTimingFunction: 'ease-out',
-                    },
-                    '22%': {
-                      transform: 'translateY(0) rotate(0deg) scaleY(1)',
-                      animationTimingFunction: 'ease-in',
-                    },
-                    '30%': {
-                      transform: 'translateY(-70px) rotate(35deg)',
-                      animationTimingFunction: 'ease-in',
-                    },
-                    '38%': {
-                      transform: 'translateY(2px) rotate(62deg) scaleY(0.83)',
-                      animationTimingFunction: 'ease-out',
-                    },
-                    '41%': {
-                      transform: 'translateY(0) rotate(62deg) scaleY(1)',
-                      animationTimingFunction: 'ease-in',
-                    },
-                    '47%': {
-                      transform: 'translateY(-32px) rotate(88deg)',
-                      animationTimingFunction: 'ease-in',
-                    },
-                    '53%': {
-                      transform: 'translateY(2px) rotate(112deg) scaleY(0.90)',
-                      animationTimingFunction: 'ease-out',
-                    },
-                    '55%': {
-                      transform: 'translateY(0) rotate(112deg) scaleY(1)',
-                      animationTimingFunction: 'ease-in',
-                    },
-                    '58%': {
-                      transform: 'translateY(-10px) rotate(122deg)',
-                      animationTimingFunction: 'ease-in',
-                    },
-                    '62%': {
-                      transform: 'translateY(0) rotate(130deg)',
-                      animationTimingFunction: 'linear',
-                    },
-                    '80%': { transform: 'translateY(0) rotate(580deg)' },
-                    '100%': { transform: 'translateY(-260px) rotate(0deg)' },
-                  },
-                  animation: 'ballBounce 5s ease-out infinite',
-                }}
-              />
-            </Box>
-            <Typography align="center" sx={{ color: tokens.onSurfaceVariant }}>
-              {t('subtitle')}
-            </Typography>
-          </Stack>
+          <AuthGatewayHeader title={t('title')} subtitle={t('subtitle')} />
 
-          <Tabs centered value={mode} onChange={handleModeChange}>
-            <Tab label={t('loginTab')} value="login" />
-            <Tab label={t('registerTab')} value="register" />
-          </Tabs>
+          <AuthGatewayModeTabs
+            mode={mode}
+            loginLabel={t('loginTab')}
+            registerLabel={t('registerTab')}
+            onChange={handleModeChange}
+          />
 
-          <Box sx={{ position: 'relative', overflow: 'hidden' }}>
-            {isTransitioning && (
-              <Box
-                aria-hidden
-                sx={{
-                  position: 'absolute',
-                  top: '50%',
-                  left: 0,
-                  right: 0,
-                  display: 'flex',
-                  justifyContent: 'flex-start',
-                  pointerEvents: 'none',
-                  zIndex: 5,
-                  transform: 'translateY(-50%)',
-                  filter: `drop-shadow(0 6px 12px ${tokens.primary}66)`,
-                }}
-              >
-                <Box
-                  sx={{
-                    width: 56,
-                    height: 56,
-                    animation: `authBallRoll${direction === 'forward' ? 'Right' : 'Left'} 600ms linear forwards`,
-                    '@keyframes authBallRollRight': {
-                      '0%': { transform: 'translateX(-72px) rotate(0deg)', opacity: 0 },
-                      '12%': { opacity: 1 },
-                      '88%': { opacity: 1 },
-                      '100%': {
-                        transform: 'translateX(calc(100% + 72px)) rotate(900deg)',
-                        opacity: 0,
-                      },
-                    },
-                    '@keyframes authBallRollLeft': {
-                      '0%': {
-                        transform: 'translateX(calc(100% + 72px)) rotate(0deg)',
-                        opacity: 0,
-                      },
-                      '12%': { opacity: 1 },
-                      '88%': { opacity: 1 },
-                      '100%': {
-                        transform: 'translateX(-72px) rotate(-900deg)',
-                        opacity: 0,
-                      },
-                    },
-                  }}
-                >
-                  <SportsSoccerIcon
-                    sx={{
-                      fontSize: 56,
-                      color: tokens.primary,
-                      animation: 'authBallSpin 200ms linear infinite',
-                      '@keyframes authBallSpin': {
-                        '0%': { transform: 'rotate(0deg)' },
-                        '100%': { transform: 'rotate(360deg)' },
-                      },
-                    }}
-                  />
-                </Box>
-              </Box>
-            )}
-
-            <Box
-              key={exiting ? `${mode}-exit` : mode}
-              onAnimationEnd={handlePanelAnimationEnd}
-              sx={{
-                willChange: 'transform, opacity, filter',
-                animation: exiting
-                  ? `authPanelExit 240ms cubic-bezier(0.4, 0, 1, 1) forwards`
-                  : `authPanelEnter 360ms cubic-bezier(0.2, 0.9, 0.3, 1)`,
-                '@keyframes authPanelExit': {
-                  '0%': { opacity: 1, transform: 'translateX(0)', filter: 'blur(0)' },
-                  '100%': {
-                    opacity: 0,
-                    transform: `translateX(${direction === 'forward' ? '-16px' : '16px'})`,
-                    filter: 'blur(2px)',
-                  },
-                },
-                '@keyframes authPanelEnter': {
-                  '0%': {
-                    opacity: 0,
-                    transform: `translateX(${direction === 'forward' ? '16px' : '-16px'})`,
-                    filter: 'blur(2px)',
-                  },
-                  '60%': { opacity: 1, filter: 'blur(0)' },
-                  '100%': { opacity: 1, transform: 'translateX(0)', filter: 'blur(0)' },
-                },
-              }}
-            >
-              <Stack spacing={2} component="form" onSubmit={handleSubmit(onSubmit)} sx={{ pt: 1 }}>
-                {mode === 'register' && (
-                  <FormField<AuthFormData>
-                    name="nickname"
-                    control={control}
-                    label={t('nicknameLabel')}
-                    placeholder={t('nicknamePlaceholder')}
-                    autoComplete="username"
-                    fullWidth
-                    sx={{
-                      animation: !exiting ? `authFieldStagger 420ms ease-out 40ms both` : 'none',
-                      '@keyframes authFieldStagger': {
-                        '0%': { opacity: 0, transform: 'translateY(8px)' },
-                        '100%': { opacity: 1, transform: 'translateY(0)' },
-                      },
-                    }}
-                  />
-                )}
-
-                <FormField<AuthFormData>
-                  name="email"
-                  control={control}
-                  label={t('emailLabel')}
-                  placeholder={t('emailPlaceholder')}
-                  autoComplete="email"
-                  fullWidth
-                />
-
-                <FormField<AuthFormData>
-                  name="password"
-                  control={control}
-                  type="password"
-                  label={t('passwordLabel')}
-                  placeholder={t('passwordPlaceholder')}
-                  autoComplete={mode === 'login' ? 'current-password' : 'new-password'}
-                  fullWidth
-                />
-                {mode === 'register' && (
-                  <FormField<AuthFormData>
-                    name="confirmPassword"
-                    control={control}
-                    type="password"
-                    label={t('confirmPasswordLabel')}
-                    placeholder={t('confirmPasswordPlaceholder')}
-                    autoComplete="new-password"
-                    fullWidth
-                    sx={{
-                      animation: !exiting ? `authFieldStagger 420ms ease-out 80ms both` : 'none',
-                    }}
-                  />
-                )}
-                <AppButton type="submit" loading={isSubmitting} fullWidth>
-                  {submitLabel}
-                </AppButton>
-              </Stack>
-            </Box>
-          </Box>
+          <AuthGatewayForm
+            mode={mode}
+            phase={phase}
+            control={control}
+            handleSubmit={handleSubmit}
+            onSubmit={submit}
+            submitLabel={submitLabel}
+            isSubmitting={isSubmitting}
+            isTransitioning={isTransitioning}
+            direction={direction}
+            onAnimationEnd={handlePanelAnimationEnd}
+            emailLabel={t('emailLabel')}
+            emailPlaceholder={t('emailPlaceholder')}
+            passwordLabel={t('passwordLabel')}
+            passwordPlaceholder={t('passwordPlaceholder')}
+            nicknameLabel={t('nicknameLabel')}
+            nicknamePlaceholder={t('nicknamePlaceholder')}
+            confirmPasswordLabel={t('confirmPasswordLabel')}
+            confirmPasswordPlaceholder={t('confirmPasswordPlaceholder')}
+          />
 
           <Divider>{t('or')}</Divider>
 
           <AppButton
             variant="secondary"
-            onClick={handleGoogleLogin}
+            onClick={handleGoogleSubmit}
             startIcon={<GoogleIcon />}
             fullWidth
           >

--- a/src/features/auth/components/organisms/AuthGatewayForm.tsx
+++ b/src/features/auth/components/organisms/AuthGatewayForm.tsx
@@ -1,0 +1,189 @@
+'use client';
+
+import type { AnimationEvent } from 'react';
+import Box from '@mui/material/Box';
+import Stack from '@mui/material/Stack';
+import FormField from '@shared/components/atoms/FormField';
+import AppButton from '@shared/components/atoms/AppButton';
+import { tokens } from '@lib/theme/theme';
+import type {
+  Control,
+  FieldValues,
+  Path,
+  SubmitHandler,
+  UseFormHandleSubmit,
+} from 'react-hook-form';
+
+type Mode = 'login' | 'register';
+
+interface AuthGatewayFormProps<T extends FieldValues> {
+  mode: Mode;
+  phase: 'idle' | 'exiting' | 'entering';
+  control: Control<T>;
+  handleSubmit: UseFormHandleSubmit<T>;
+  onSubmit: SubmitHandler<T>;
+  submitLabel: string;
+  isSubmitting: boolean;
+  isTransitioning: boolean;
+  direction: 'forward' | 'backward';
+  onAnimationEnd: (event: AnimationEvent<HTMLDivElement>) => void;
+  emailLabel: string;
+  emailPlaceholder: string;
+  passwordLabel: string;
+  passwordPlaceholder: string;
+  nicknameLabel: string;
+  nicknamePlaceholder: string;
+  confirmPasswordLabel: string;
+  confirmPasswordPlaceholder: string;
+}
+
+const AuthGatewayForm = <T extends FieldValues>({
+  mode,
+  phase,
+  control,
+  handleSubmit,
+  onSubmit,
+  submitLabel,
+  isSubmitting,
+  isTransitioning,
+  direction,
+  onAnimationEnd,
+  emailLabel,
+  emailPlaceholder,
+  passwordLabel,
+  passwordPlaceholder,
+  nicknameLabel,
+  nicknamePlaceholder,
+  confirmPasswordLabel,
+  confirmPasswordPlaceholder,
+}: AuthGatewayFormProps<T>) => (
+  <Box sx={{ position: 'relative', overflow: 'hidden' }}>
+    {isTransitioning && (
+      <Box
+        aria-hidden
+        sx={{
+          position: 'absolute',
+          top: '50%',
+          left: 0,
+          right: 0,
+          display: 'flex',
+          justifyContent: 'flex-start',
+          pointerEvents: 'none',
+          zIndex: 5,
+          transform: 'translateY(-50%)',
+          filter: `drop-shadow(0 6px 12px ${tokens.primary}66)`,
+        }}
+      >
+        <Box
+          sx={{
+            width: 56,
+            height: 56,
+            animation: `authBallRoll${direction === 'forward' ? 'Right' : 'Left'} 600ms linear forwards`,
+            '@keyframes authBallRollRight': {
+              '0%': { transform: 'translateX(-72px) rotate(0deg)', opacity: 0 },
+              '12%': { opacity: 1 },
+              '88%': { opacity: 1 },
+              '100%': {
+                transform: 'translateX(calc(100% + 72px)) rotate(900deg)',
+                opacity: 0,
+              },
+            },
+            '@keyframes authBallRollLeft': {
+              '0%': {
+                transform: 'translateX(calc(100% + 72px)) rotate(0deg)',
+                opacity: 0,
+              },
+              '12%': { opacity: 1 },
+              '88%': { opacity: 1 },
+              '100%': {
+                transform: 'translateX(-72px) rotate(-900deg)',
+                opacity: 0,
+              },
+            },
+          }}
+        />
+      </Box>
+    )}
+
+    <Box
+      key={`${mode}-${phase}`}
+      onAnimationEnd={onAnimationEnd}
+      sx={{
+        willChange: 'transform, opacity, filter',
+        animation:
+          phase === 'exiting'
+            ? `authPanelExit 240ms cubic-bezier(0.4, 0, 1, 1) forwards`
+            : phase === 'entering'
+              ? `authPanelEnter 360ms cubic-bezier(0.2, 0.9, 0.3, 1) forwards`
+              : 'none',
+        '@keyframes authPanelExit': {
+          '0%': { opacity: 1, transform: 'translateX(0)', filter: 'blur(0)' },
+          '100%': {
+            opacity: 0,
+            transform: `translateX(${direction === 'forward' ? '-16px' : '16px'})`,
+            filter: 'blur(2px)',
+          },
+        },
+        '@keyframes authPanelEnter': {
+          '0%': {
+            opacity: 0,
+            transform: `translateX(${direction === 'forward' ? '16px' : '-16px'})`,
+            filter: 'blur(2px)',
+          },
+          '60%': { opacity: 1, filter: 'blur(0)' },
+          '100%': { opacity: 1, transform: 'translateX(0)', filter: 'blur(0)' },
+        },
+      }}
+    >
+      <Stack spacing={2} component="form" onSubmit={handleSubmit(onSubmit)} sx={{ pt: 1 }}>
+        {mode === 'register' && (
+          <FormField<T>
+            name={'nickname' as Path<T>}
+            control={control}
+            label={nicknameLabel}
+            placeholder={nicknamePlaceholder}
+            autoComplete="username"
+            fullWidth
+          />
+        )}
+
+        <FormField<T>
+          name={'email' as Path<T>}
+          control={control}
+          label={emailLabel}
+          placeholder={emailPlaceholder}
+          autoComplete="email"
+          fullWidth
+        />
+
+        <FormField<T>
+          name={'password' as Path<T>}
+          control={control}
+          type="password"
+          label={passwordLabel}
+          placeholder={passwordPlaceholder}
+          autoComplete={mode === 'login' ? 'current-password' : 'new-password'}
+          fullWidth
+        />
+
+        {mode === 'register' && (
+          <FormField<T>
+            name={'confirmPassword' as Path<T>}
+            control={control}
+            type="password"
+            label={confirmPasswordLabel}
+            placeholder={confirmPasswordPlaceholder}
+            autoComplete="new-password"
+            fullWidth
+          />
+        )}
+
+        <AppButton type="submit" loading={isSubmitting} fullWidth>
+          {submitLabel}
+        </AppButton>
+      </Stack>
+    </Box>
+  </Box>
+);
+
+export default AuthGatewayForm;

--- a/src/features/auth/components/organisms/RequireAdmin.tsx
+++ b/src/features/auth/components/organisms/RequireAdmin.tsx
@@ -21,7 +21,7 @@ const RequireAdmin = ({ children }: { children: React.ReactNode }) => {
     }
 
     if (!isAdmin) {
-      router.replace('/home');
+      router.replace('/403');
     }
   }, [hydrated, isAdmin, router, session]);
 

--- a/src/features/auth/components/organisms/RequireAdmin.tsx
+++ b/src/features/auth/components/organisms/RequireAdmin.tsx
@@ -1,0 +1,49 @@
+'use client';
+
+import { useEffect } from 'react';
+import { useRouter } from 'next/navigation';
+import Box from '@mui/material/Box';
+import CircularProgress from '@mui/material/CircularProgress';
+import { useAuthSession } from '@features/auth/hooks/useAuthSession';
+
+const RequireAdmin = ({ children }: { children: React.ReactNode }) => {
+  const router = useRouter();
+  const { hydrated, session, isAdmin } = useAuthSession();
+
+  useEffect(() => {
+    if (!hydrated) {
+      return;
+    }
+
+    if (!session) {
+      router.replace('/auth');
+      return;
+    }
+
+    if (!isAdmin) {
+      router.replace('/home');
+    }
+  }, [hydrated, isAdmin, router, session]);
+
+  if (!hydrated) {
+    return (
+      <Box
+        sx={{
+          minHeight: '100vh',
+          display: 'grid',
+          placeItems: 'center',
+        }}
+      >
+        <CircularProgress />
+      </Box>
+    );
+  }
+
+  if (!session || !isAdmin) {
+    return null;
+  }
+
+  return <>{children}</>;
+};
+
+export default RequireAdmin;

--- a/src/features/auth/data/mockUsers.ts
+++ b/src/features/auth/data/mockUsers.ts
@@ -1,0 +1,44 @@
+import type { StoredUser } from '../types/auth';
+
+export const mockUsers: StoredUser[] = [
+  {
+    id: 'admin-user',
+    email: 'admin@admin.com',
+    displayName: 'admin',
+    provider: 'email',
+    emailVerified: true,
+    role: 'admin',
+    password: '12345678',
+  },
+  {
+    id: 'mock-user-1',
+    email: 'test@test.com',
+    displayName: 'test',
+    provider: 'email',
+    emailVerified: true,
+    role: 'user',
+    password: '12345678',
+  },
+  {
+    id: 'mock-user-2',
+    email: 'ana@test.com',
+    displayName: 'ana',
+    provider: 'email',
+    emailVerified: true,
+    role: 'user',
+    password: '12345678',
+  },
+  {
+    id: 'mock-user-3',
+    email: 'diego@test.com',
+    displayName: 'diego',
+    provider: 'email',
+    emailVerified: true,
+    role: 'user',
+    password: '12345678',
+  },
+];
+
+export const mockAdminUser = mockUsers[0];
+export const mockAdminEmail = mockAdminUser.email;
+export const mockAdminPassword = mockAdminUser.password ?? '12345678';

--- a/src/features/auth/hooks/useAuthGateway.ts
+++ b/src/features/auth/hooks/useAuthGateway.ts
@@ -1,0 +1,194 @@
+'use client';
+
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useRouter } from 'next/navigation';
+import { useForm, type Resolver } from 'react-hook-form';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { useTranslations } from 'next-intl';
+import { loginSchema, registerFormSchema } from '../lib/schemas';
+import type { RegisterFormInput } from '../lib/schemas';
+import { useAuthStore } from '../store/useAuthStore';
+
+type Mode = 'login' | 'register';
+type TransitionPhase = 'idle' | 'exiting' | 'entering';
+type AuthFormData = RegisterFormInput;
+type ErrorNode = Record<string, unknown>;
+
+const EMPTY_FORM: AuthFormData = {
+  email: '',
+  password: '',
+  nickname: '',
+  confirmPassword: '',
+};
+
+const translateErrorTree = (
+  errors: ErrorNode | undefined,
+  translate: (key: string) => string,
+): ErrorNode => {
+  if (!errors) return {};
+  const out: ErrorNode = {};
+  for (const [key, value] of Object.entries(errors)) {
+    if (value && typeof value === 'object') {
+      const node = value as ErrorNode;
+      if (typeof node.message === 'string' && node.message) {
+        out[key] = { ...node, message: translate(node.message) };
+      } else {
+        out[key] = translateErrorTree(node, translate);
+      }
+    } else {
+      out[key] = value;
+    }
+  }
+  return out;
+};
+
+export const useAuthGateway = () => {
+  const router = useRouter();
+  const t = useTranslations('auth');
+  const tRoot = useTranslations();
+
+  const [mode, setMode] = useState<Mode>('login');
+  const [pendingMode, setPendingMode] = useState<Mode | null>(null);
+  const [phase, setPhase] = useState<TransitionPhase>('idle');
+  const [direction, setDirection] = useState<'forward' | 'backward'>('forward');
+  const [notice, setNotice] = useState<{ type: 'success' | 'error'; text: string } | null>(null);
+
+  const isTransitioning = phase !== 'idle';
+
+  const translateKey = useCallback(
+    (key?: string, fallback?: string) => (key ? tRoot(key) : (fallback ?? '')),
+    [tRoot],
+  );
+
+  const resolver = useMemo<Resolver<AuthFormData>>(() => {
+    const base = zodResolver(
+      mode === 'register' ? registerFormSchema : loginSchema,
+    ) as unknown as Resolver<AuthFormData>;
+
+    const wrapped: Resolver<AuthFormData> = async (values, context, options) => {
+      const result = await base(values, context, options);
+      return {
+        ...result,
+        errors: translateErrorTree(result.errors as ErrorNode, translateKey),
+      } as Awaited<ReturnType<Resolver<AuthFormData>>>;
+    };
+    return wrapped;
+  }, [mode, translateKey]);
+
+  const {
+    handleSubmit,
+    control,
+    formState: { isSubmitting },
+    setError,
+    reset,
+    clearErrors,
+  } = useForm<AuthFormData>({
+    defaultValues: EMPTY_FORM,
+    mode: 'onBlur',
+    reValidateMode: 'onChange',
+    resolver,
+  });
+
+  const registerWithEmail = useAuthStore((state) => state.registerWithEmail);
+  const loginWithEmail = useAuthStore((state) => state.loginWithEmail);
+  const loginWithGoogle = useAuthStore((state) => state.loginWithGoogle);
+
+  useEffect(() => {
+    clearErrors();
+  }, [mode, clearErrors]);
+
+  const handleModeChange = (_: React.SyntheticEvent, value: Mode) => {
+    if (value === mode || isTransitioning) return;
+    setDirection(value === 'register' ? 'forward' : 'backward');
+    setPendingMode(value);
+    setPhase('exiting');
+  };
+
+  const handlePanelAnimationEnd = (event: React.AnimationEvent<HTMLDivElement>) => {
+    if (event.animationName === 'authPanelExit' && phase === 'exiting' && pendingMode) {
+      setMode(pendingMode);
+      setPhase('entering');
+      return;
+    }
+    if (event.animationName === 'authPanelEnter' && phase === 'entering') {
+      setPhase('idle');
+      setPendingMode(null);
+    }
+  };
+
+  const submit = useCallback(
+    (values: AuthFormData) => {
+      setNotice(null);
+
+      const result =
+        mode === 'register'
+          ? registerWithEmail({
+              email: values.email,
+              password: values.password,
+              nickname: values.nickname,
+            })
+          : loginWithEmail({ email: values.email, password: values.password });
+
+      if (!result.ok) {
+        if (result.fieldErrors?.email) {
+          setError('email', { message: translateKey(result.fieldErrors.email) });
+        }
+        if (result.fieldErrors?.password) {
+          setError('password', { message: translateKey(result.fieldErrors.password) });
+        }
+        if (result.fieldErrors?.nickname) {
+          setError('nickname', { message: translateKey(result.fieldErrors.nickname) });
+        }
+        if (result.messageKey) {
+          setNotice({ type: 'error', text: translateKey(result.messageKey, t('genericError')) });
+        }
+        return;
+      }
+
+      setNotice({
+        type: 'success',
+        text: translateKey(result.messageKey, t('sessionCreated')),
+      });
+      reset();
+      router.replace('/home');
+    },
+    [loginWithEmail, mode, registerWithEmail, reset, router, setError, t, translateKey],
+  );
+
+  const handleGoogleSubmit = useCallback(() => {
+    const result = loginWithGoogle();
+
+    if (!result.ok) {
+      setNotice({ type: 'error', text: translateKey(result.messageKey, t('genericError')) });
+      return;
+    }
+
+    setNotice({
+      type: 'success',
+      text: translateKey(result.messageKey, t('sessionCreated')),
+    });
+    router.replace('/home');
+  }, [loginWithGoogle, router, t, translateKey]);
+
+  const submitLabel = useMemo(
+    () => (mode === 'login' ? t('loginCta') : t('registerCta')),
+    [mode, t],
+  );
+
+  return {
+    mode,
+    notice,
+    control,
+    isSubmitting,
+    isTransitioning,
+    direction,
+    submitLabel,
+    handleSubmit,
+    handleModeChange,
+    handlePanelAnimationEnd,
+    handleGoogleSubmit,
+    submit,
+    t,
+    phase,
+  };
+};

--- a/src/features/auth/hooks/useAuthSession.ts
+++ b/src/features/auth/hooks/useAuthSession.ts
@@ -1,14 +1,18 @@
 'use client';
 
 import { useAuthStore } from '../store/useAuthStore';
+import { mockAdminEmail } from '../data/mockUsers';
 
 export const useAuthSession = () => {
   const session = useAuthStore((state) => state.session);
   const hydrated = useAuthStore((state) => state.hydrated);
+  const isAdmin =
+    session?.user.role === 'admin' || session?.user.email.trim().toLowerCase() === mockAdminEmail;
 
   return {
     session,
     hydrated,
+    isAdmin,
     isAuthenticated: hydrated && !!session,
   };
 };

--- a/src/features/auth/hooks/useAuthSession.ts
+++ b/src/features/auth/hooks/useAuthSession.ts
@@ -1,13 +1,12 @@
 'use client';
 
 import { useAuthStore } from '../store/useAuthStore';
-import { mockAdminEmail } from '../data/mockUsers';
+import { isAdminSession } from '../lib/adminAccess';
 
 export const useAuthSession = () => {
   const session = useAuthStore((state) => state.session);
   const hydrated = useAuthStore((state) => state.hydrated);
-  const isAdmin =
-    session?.user.role === 'admin' || session?.user.email.trim().toLowerCase() === mockAdminEmail;
+  const isAdmin = isAdminSession(session);
 
   return {
     session,

--- a/src/features/auth/index.ts
+++ b/src/features/auth/index.ts
@@ -1,12 +1,24 @@
 export { useAuthStore } from './store/useAuthStore';
 export { useAuthSession } from './hooks/useAuthSession';
+export { useAuthGateway } from './hooks/useAuthGateway';
 export { default as AuthGateway } from './components/organisms/AuthGateway';
 export { default as RequireAuth } from './components/organisms/RequireAuth';
+export { default as RequireAdmin } from './components/organisms/RequireAdmin';
 export { default as RequireGuest } from './components/organisms/RequireGuest';
+export { default as AuthGatewayHeader } from './components/molecules/AuthGatewayHeader';
+export { default as AuthGatewayModeTabs } from './components/molecules/AuthGatewayModeTabs';
+export { default as AuthGatewayForm } from './components/organisms/AuthGatewayForm';
+export { authService } from './services/authService';
+export type {
+  AuthGatewayPort,
+  AuthGatewayResult,
+  AuthGatewayState,
+} from './services/AuthGatewayPort';
 export type {
   AuthActionResult,
   AuthFieldErrors,
   AuthProvider,
+  AuthRole,
   AuthSession,
   AuthUser,
   CredentialsPayload,

--- a/src/features/auth/lib/adminAccess.ts
+++ b/src/features/auth/lib/adminAccess.ts
@@ -1,0 +1,10 @@
+import type { ApiError } from '@lib/api/types';
+import type { AuthSession } from '../types/auth';
+
+export const isAdminSession = (session: AuthSession | null | undefined): boolean =>
+  session?.user.role === 'admin' || session?.user.email.trim().toLowerCase() === 'admin@admin.com';
+
+export const createForbiddenError = (message = 'No tienes permiso para esta acción'): ApiError => ({
+  message,
+  code: 403,
+});

--- a/src/features/auth/services/AuthGatewayPort.ts
+++ b/src/features/auth/services/AuthGatewayPort.ts
@@ -1,0 +1,22 @@
+import type {
+  AuthActionResult,
+  AuthSession,
+  CredentialsPayload,
+  RegisterPayload,
+  StoredUser,
+} from '../types/auth';
+
+export type AuthGatewayResult = AuthActionResult & {
+  session?: AuthSession;
+  users?: StoredUser[];
+};
+
+export interface AuthGatewayState {
+  users: StoredUser[];
+}
+
+export interface AuthGatewayPort {
+  registerWithEmail(payload: RegisterPayload, state: AuthGatewayState): AuthGatewayResult;
+  loginWithEmail(payload: CredentialsPayload, state: AuthGatewayState): AuthGatewayResult;
+  loginWithGoogle(state: AuthGatewayState): AuthGatewayResult;
+}

--- a/src/features/auth/services/authService.ts
+++ b/src/features/auth/services/authService.ts
@@ -1,0 +1,13 @@
+import type { AuthGatewayPort, AuthGatewayResult, AuthGatewayState } from './AuthGatewayPort';
+import { MockAuthGateway } from './gateways/MockAuthGateway';
+import type { CredentialsPayload, RegisterPayload } from '../types/auth';
+
+const gateway: AuthGatewayPort = new MockAuthGateway();
+
+export const authService = {
+  registerWithEmail: (payload: RegisterPayload, state: AuthGatewayState): AuthGatewayResult =>
+    gateway.registerWithEmail(payload, state),
+  loginWithEmail: (payload: CredentialsPayload, state: AuthGatewayState): AuthGatewayResult =>
+    gateway.loginWithEmail(payload, state),
+  loginWithGoogle: (state: AuthGatewayState): AuthGatewayResult => gateway.loginWithGoogle(state),
+};

--- a/src/features/auth/services/gateways/MockAuthGateway.ts
+++ b/src/features/auth/services/gateways/MockAuthGateway.ts
@@ -1,0 +1,195 @@
+import { loginSchema as credentialsSchema, registerSchema } from '../../lib/schemas';
+import type { AuthGatewayPort, AuthGatewayResult, AuthGatewayState } from '../AuthGatewayPort';
+import type {
+  AuthSession,
+  CredentialsPayload,
+  RegisterPayload,
+  StoredUser,
+} from '../../types/auth';
+import { mockAdminEmail, mockAdminPassword, mockAdminUser } from '../../data/mockUsers';
+
+const EMAIL_CONFIRMATION_REQUIRED = false;
+
+const normalizeEmail = (email: string) => email.trim().toLowerCase();
+
+const isAdminCredentials = (email: string, password: string) =>
+  normalizeEmail(email) === mockAdminEmail && password === mockAdminPassword;
+
+const createToken = () =>
+  typeof crypto !== 'undefined' && 'randomUUID' in crypto
+    ? crypto.randomUUID()
+    : `${Date.now()}-${Math.random().toString(16).slice(2)}`;
+
+const buildUser = (
+  email: string,
+  provider: StoredUser['provider'],
+  password?: string,
+  role: StoredUser['role'] = 'user',
+): StoredUser => ({
+  id: createToken(),
+  email,
+  displayName: email.split('@')[0],
+  provider,
+  emailVerified: !EMAIL_CONFIRMATION_REQUIRED,
+  role,
+  password,
+});
+
+const buildSession = (user: StoredUser): AuthSession => ({
+  token: createToken(),
+  user,
+  createdAt: new Date().toISOString(),
+});
+
+const buildAdminUser = (): StoredUser => ({
+  ...mockAdminUser,
+  role: 'admin',
+});
+
+const ok = (result: AuthGatewayResult): AuthGatewayResult => result;
+
+export class MockAuthGateway implements AuthGatewayPort {
+  registerWithEmail(payload: RegisterPayload, state: AuthGatewayState): AuthGatewayResult {
+    const parsed = registerSchema.safeParse(payload);
+
+    if (!parsed.success) {
+      const fieldErrors = parsed.error.flatten().fieldErrors;
+      return ok({
+        ok: false,
+        messageKey: 'auth.errors.formInvalid',
+        fieldErrors: {
+          email: fieldErrors.email?.[0],
+          password: fieldErrors.password?.[0],
+          nickname: fieldErrors.nickname?.[0],
+        },
+      });
+    }
+
+    const normalizedEmail = normalizeEmail(parsed.data.email);
+    const duplicatedEmail = state.users.some(
+      (user) => normalizeEmail(user.email) === normalizedEmail,
+    );
+    if (duplicatedEmail) {
+      return ok({
+        ok: false,
+        messageKey: 'auth.errors.emailTaken',
+        fieldErrors: { email: 'auth.errors.emailMustBeUnique' },
+      });
+    }
+
+    if (isAdminCredentials(parsed.data.email, parsed.data.password)) {
+      return ok({
+        ok: false,
+        messageKey: 'auth.errors.emailTaken',
+        fieldErrors: { email: 'auth.errors.emailMustBeUnique' },
+      });
+    }
+
+    const duplicatedNickname = state.users.some(
+      (user) => user.displayName.toLowerCase() === parsed.data.nickname.toLowerCase(),
+    );
+    if (duplicatedNickname) {
+      return ok({
+        ok: false,
+        messageKey: 'auth.errors.nicknameTaken',
+        fieldErrors: { nickname: 'auth.errors.nicknameMustBeUnique' },
+      });
+    }
+
+    const user = buildUser(normalizedEmail, 'email', parsed.data.password);
+    user.displayName = parsed.data.nickname;
+    const session = buildSession(user);
+
+    return ok({
+      ok: true,
+      messageKey: EMAIL_CONFIRMATION_REQUIRED
+        ? 'auth.success.checkEmail'
+        : 'auth.success.registered',
+      session,
+      users: [...state.users, user],
+    });
+  }
+
+  loginWithEmail(payload: CredentialsPayload, state: AuthGatewayState): AuthGatewayResult {
+    const parsed = credentialsSchema.safeParse(payload);
+
+    if (!parsed.success) {
+      const fieldErrors = parsed.error.flatten().fieldErrors;
+      return ok({
+        ok: false,
+        messageKey: 'auth.errors.invalidCredentials',
+        fieldErrors: {
+          email: fieldErrors.email?.[0],
+          password: fieldErrors.password?.[0],
+        },
+      });
+    }
+
+    const normalizedEmail = normalizeEmail(parsed.data.email);
+    if (isAdminCredentials(parsed.data.email, parsed.data.password)) {
+      const existingAdminUser = state.users.find(
+        (candidate) =>
+          candidate.id === mockAdminUser.id || normalizeEmail(candidate.email) === mockAdminEmail,
+      );
+      const adminUser: StoredUser = existingAdminUser
+        ? { ...existingAdminUser, role: 'admin' }
+        : buildAdminUser();
+
+      const session = buildSession(adminUser);
+
+      return ok({
+        ok: true,
+        messageKey: 'auth.success.loggedIn',
+        session,
+        users: existingAdminUser
+          ? state.users.map((candidate) =>
+              candidate.id === existingAdminUser.id ||
+              normalizeEmail(candidate.email) === mockAdminEmail
+                ? { ...candidate, role: 'admin' }
+                : candidate,
+            )
+          : [...state.users, adminUser],
+      });
+    }
+
+    const existing = state.users.find(
+      (candidate) =>
+        normalizeEmail(candidate.email) === normalizedEmail && candidate.provider === 'email',
+    );
+
+    if (existing) {
+      if (existing.password !== parsed.data.password) {
+        return ok({ ok: false, messageKey: 'auth.errors.invalidCredentials' });
+      }
+
+      const session = buildSession(existing);
+      return ok({ ok: true, messageKey: 'auth.success.loggedIn', session });
+    }
+
+    const user = buildUser(normalizedEmail, 'email', parsed.data.password);
+    const session = buildSession(user);
+
+    return ok({
+      ok: true,
+      messageKey: 'auth.success.loggedIn',
+      session,
+      users: [...state.users, user],
+    });
+  }
+
+  loginWithGoogle(state: AuthGatewayState): AuthGatewayResult {
+    const existingGoogleUser = state.users.find((user) => user.provider === 'google');
+
+    const googleUser: StoredUser =
+      existingGoogleUser ?? buildUser('google.player@skorify.app', 'google');
+
+    const session = buildSession(googleUser);
+
+    return ok({
+      ok: true,
+      messageKey: 'auth.success.googleLoggedIn',
+      session,
+      users: existingGoogleUser ? state.users : [...state.users, googleUser],
+    });
+  }
+}

--- a/src/features/auth/store/useAuthStore.ts
+++ b/src/features/auth/store/useAuthStore.ts
@@ -2,8 +2,8 @@
 
 import { create } from 'zustand';
 import { createJSONStorage, persist } from 'zustand/middleware';
-import { env } from '@lib/env';
-import { loginSchema as credentialsSchema, registerSchema } from '../lib/schemas';
+import { mockUsers } from '../data/mockUsers';
+import { authService } from '../services/authService';
 import type {
   AuthActionResult,
   AuthSession,
@@ -11,9 +11,6 @@ import type {
   RegisterPayload,
   StoredUser,
 } from '../types/auth';
-
-const EMAIL_CONFIRMATION_REQUIRED = false;
-const isMockMode = env.NEXT_PUBLIC_AUTH_MODE === 'mock';
 
 type AuthState = {
   hydrated: boolean;
@@ -25,13 +22,6 @@ type AuthState = {
   loginWithGoogle: () => AuthActionResult;
   logout: () => void;
 };
-
-const normalizeEmail = (email: string) => email.trim().toLowerCase();
-
-const createToken = () =>
-  typeof crypto !== 'undefined' && 'randomUUID' in crypto
-    ? crypto.randomUUID()
-    : `${Date.now()}-${Math.random().toString(16).slice(2)}`;
 
 const persistToken = (token: string | null) => {
   if (typeof window === 'undefined') {
@@ -45,149 +35,48 @@ const persistToken = (token: string | null) => {
   }
 };
 
-const buildUser = (
-  email: string,
-  provider: StoredUser['provider'],
-  password?: string,
-): StoredUser => ({
-  id: createToken(),
-  email,
-  displayName: email.split('@')[0],
-  provider,
-  emailVerified: !EMAIL_CONFIRMATION_REQUIRED,
-  password,
-});
-
-const buildSession = (user: StoredUser): AuthSession => ({
-  token: createToken(),
-  user,
-  createdAt: new Date().toISOString(),
-});
-
 export const useAuthStore = create<AuthState>()(
   persist(
     (set, get) => ({
       hydrated: false,
       session: null,
-      users: [],
+      users: mockUsers,
       setHydrated: (value) => set({ hydrated: value }),
 
       registerWithEmail: (payload) => {
-        const parsed = registerSchema.safeParse(payload);
-
-        if (!parsed.success) {
-          const fieldErrors = parsed.error.flatten().fieldErrors;
-          return {
-            ok: false,
-            messageKey: 'auth.errors.formInvalid',
-            fieldErrors: {
-              email: fieldErrors.email?.[0],
-              password: fieldErrors.password?.[0],
-              nickname: fieldErrors.nickname?.[0],
-            },
-          };
+        const result = authService.registerWithEmail(payload, { users: get().users });
+        if (result.ok && result.session) {
+          set((state) => ({
+            users: result.users ?? state.users,
+            session: result.session,
+          }));
+          persistToken(result.session.token);
         }
-
-        const normalizedEmail = normalizeEmail(parsed.data.email);
-        const users = get().users;
-
-        const duplicatedEmail = users.some(
-          (user) => normalizeEmail(user.email) === normalizedEmail,
-        );
-        if (duplicatedEmail) {
-          return {
-            ok: false,
-            messageKey: 'auth.errors.emailTaken',
-            fieldErrors: { email: 'auth.errors.emailMustBeUnique' },
-          };
-        }
-
-        const duplicatedNickname = users.some(
-          (user) => user.displayName.toLowerCase() === parsed.data.nickname.toLowerCase(),
-        );
-        if (duplicatedNickname) {
-          return {
-            ok: false,
-            messageKey: 'auth.errors.nicknameTaken',
-            fieldErrors: { nickname: 'auth.errors.nicknameMustBeUnique' },
-          };
-        }
-
-        const user = buildUser(normalizedEmail, 'email', parsed.data.password);
-        user.displayName = parsed.data.nickname;
-        const session = buildSession(user);
-
-        set((state) => ({ users: [...state.users, user], session }));
-        persistToken(session.token);
-
-        return {
-          ok: true,
-          messageKey: EMAIL_CONFIRMATION_REQUIRED
-            ? 'auth.success.checkEmail'
-            : 'auth.success.registered',
-        };
+        return result;
       },
 
       loginWithEmail: (payload) => {
-        const parsed = credentialsSchema.safeParse(payload);
-
-        if (!parsed.success) {
-          const fieldErrors = parsed.error.flatten().fieldErrors;
-          return {
-            ok: false,
-            messageKey: 'auth.errors.invalidCredentials',
-            fieldErrors: {
-              email: fieldErrors.email?.[0],
-              password: fieldErrors.password?.[0],
-            },
-          };
+        const result = authService.loginWithEmail(payload, { users: get().users });
+        if (result.ok && result.session) {
+          set((state) => ({
+            users: result.users ?? state.users,
+            session: result.session,
+          }));
+          persistToken(result.session.token);
         }
-
-        const normalizedEmail = normalizeEmail(parsed.data.email);
-        const existing = get().users.find(
-          (candidate) =>
-            normalizeEmail(candidate.email) === normalizedEmail && candidate.provider === 'email',
-        );
-
-        if (existing) {
-          if (!isMockMode && existing.password !== parsed.data.password) {
-            return { ok: false, messageKey: 'auth.errors.invalidCredentials' };
-          }
-
-          const session = buildSession(existing);
-          set({ session });
-          persistToken(session.token);
-          return { ok: true, messageKey: 'auth.success.loggedIn' };
-        }
-
-        if (!isMockMode) {
-          return { ok: false, messageKey: 'auth.errors.invalidCredentials' };
-        }
-
-        const user = buildUser(normalizedEmail, 'email', parsed.data.password);
-        const session = buildSession(user);
-
-        set((state) => ({ users: [...state.users, user], session }));
-        persistToken(session.token);
-
-        return { ok: true, messageKey: 'auth.success.loggedIn' };
+        return result;
       },
 
       loginWithGoogle: () => {
-        const users = get().users;
-        const existingGoogleUser = users.find((user) => user.provider === 'google');
-
-        const googleUser: StoredUser =
-          existingGoogleUser ?? buildUser('google.player@skorify.app', 'google');
-        if (!existingGoogleUser) {
-          set((state) => ({ users: [...state.users, googleUser] }));
+        const result = authService.loginWithGoogle({ users: get().users });
+        if (result.ok && result.session) {
+          set((state) => ({
+            users: result.users ?? state.users,
+            session: result.session,
+          }));
+          persistToken(result.session.token);
         }
-
-        const session = buildSession(googleUser);
-        set({ session });
-        persistToken(session.token);
-
-        return { ok: true, messageKey: 'auth.success.googleLoggedIn' };
+        return result;
       },
 
       logout: () => {

--- a/src/features/auth/types/auth.ts
+++ b/src/features/auth/types/auth.ts
@@ -1,4 +1,5 @@
 export type AuthProvider = 'email' | 'google';
+export type AuthRole = 'user' | 'admin';
 
 export interface AuthUser {
   id: string;
@@ -6,6 +7,7 @@ export interface AuthUser {
   displayName: string;
   provider: AuthProvider;
   emailVerified: boolean;
+  role?: AuthRole;
 }
 
 export interface AuthSession {

--- a/src/features/matches/components/organisms/MatchResultSelectionPanel.tsx
+++ b/src/features/matches/components/organisms/MatchResultSelectionPanel.tsx
@@ -15,6 +15,7 @@ import AppCard from '@shared/components/molecules/AppCard';
 import PageHeader from '@shared/components/molecules/PageHeader';
 import { APPBAR_HEIGHT } from '@shared/components/organisms/DashboardNavbar';
 import { tokens } from '@lib/theme/theme';
+import { useAuthSession } from '@features/auth/hooks/useAuthSession';
 import MatchAutocompleteField, {
   type MatchAutocompleteOption,
 } from '../atoms/MatchAutocompleteField';
@@ -32,7 +33,7 @@ const MatchResultSelectionPanel = () => {
   const { matches, teams, tournaments, updateMatchResult } = useMatchesStore();
   const [submitFeedback, setSubmitFeedback] = useState<SubmitFeedback | null>(null);
   const [isDrawerOpen, setIsDrawerOpen] = useState(false);
-  const isAdmin = true; // TODO: Replace with real user role check
+  const { isAdmin } = useAuthSession();
 
   const {
     control,

--- a/src/features/matches/index.ts
+++ b/src/features/matches/index.ts
@@ -1,4 +1,3 @@
-export { default as MatchResultSelectionPanel } from './components/organisms/MatchResultSelectionPanel';
 export { default as MatchesHome } from './components/organisms/MatchesHome';
 export type { Match, MatchScore, MatchStatus, MatchTeam } from './types';
 export { matchesService } from './services/matchesService';

--- a/src/features/users/hooks/useCreateUser.ts
+++ b/src/features/users/hooks/useCreateUser.ts
@@ -2,6 +2,8 @@
 
 import { useCallback, useState } from 'react';
 import { api } from '@lib/api';
+import { createForbiddenError } from '@features/auth/lib/adminAccess';
+import { useAuthSession } from '@features/auth/hooks/useAuthSession';
 import {
   skorifyEndpoints,
   type CreateUserPayload,
@@ -24,24 +26,33 @@ const initialState: UseCreateUserState = {
 
 export const useCreateUser = () => {
   const [state, setState] = useState<UseCreateUserState>(initialState);
+  const { hydrated, isAdmin } = useAuthSession();
 
-  const createUser = useCallback(async (payload: CreateUserPayload): Promise<UserDto | null> => {
-    setState({ isLoading: true, error: null, data: null });
+  const createUser = useCallback(
+    async (payload: CreateUserPayload): Promise<UserDto | null> => {
+      if (!hydrated || !isAdmin) {
+        setState({ isLoading: false, error: createForbiddenError(), data: null });
+        return null;
+      }
 
-    const result = await api.put<SkorifyEnvelope<UserDto>, CreateUserPayload>(
-      skorifyEndpoints.user.create,
-      payload,
-    );
+      setState({ isLoading: true, error: null, data: null });
 
-    if (result.success) {
-      const data = result.data.data;
-      setState({ isLoading: false, error: null, data });
-      return data;
-    }
+      const result = await api.put<SkorifyEnvelope<UserDto>, CreateUserPayload>(
+        skorifyEndpoints.user.create,
+        payload,
+      );
 
-    setState({ isLoading: false, error: result.error, data: null });
-    return null;
-  }, []);
+      if (result.success) {
+        const data = result.data.data;
+        setState({ isLoading: false, error: null, data });
+        return data;
+      }
+
+      setState({ isLoading: false, error: result.error, data: null });
+      return null;
+    },
+    [hydrated, isAdmin],
+  );
 
   const reset = useCallback(() => setState(initialState), []);
 

--- a/src/features/users/hooks/useGetUserById.ts
+++ b/src/features/users/hooks/useGetUserById.ts
@@ -2,6 +2,8 @@
 
 import { useCallback, useState } from 'react';
 import { api } from '@lib/api';
+import { createForbiddenError } from '@features/auth/lib/adminAccess';
+import { useAuthSession } from '@features/auth/hooks/useAuthSession';
 import {
   skorifyEndpoints,
   type GetUserByIdParams,
@@ -24,24 +26,33 @@ const initialState: UseGetUserByIdState = {
 
 export const useGetUserById = () => {
   const [state, setState] = useState<UseGetUserByIdState>(initialState);
+  const { hydrated, isAdmin } = useAuthSession();
 
-  const getUserById = useCallback(async (params: GetUserByIdParams): Promise<UserDto | null> => {
-    setState((prev) => ({ ...prev, isLoading: true, error: null }));
+  const getUserById = useCallback(
+    async (params: GetUserByIdParams): Promise<UserDto | null> => {
+      if (!hydrated || !isAdmin) {
+        setState({ isLoading: false, error: createForbiddenError(), data: null });
+        return null;
+      }
 
-    const result = await api.get<SkorifyEnvelope<UserDto>>(
-      skorifyEndpoints.user.getById,
-      params as unknown as Record<string, unknown>,
-    );
+      setState((prev) => ({ ...prev, isLoading: true, error: null }));
 
-    if (result.success) {
-      const data = result.data.data;
-      setState({ isLoading: false, error: null, data });
-      return data;
-    }
+      const result = await api.get<SkorifyEnvelope<UserDto>>(
+        skorifyEndpoints.user.getById,
+        params as unknown as Record<string, unknown>,
+      );
 
-    setState({ isLoading: false, error: result.error, data: null });
-    return null;
-  }, []);
+      if (result.success) {
+        const data = result.data.data;
+        setState({ isLoading: false, error: null, data });
+        return data;
+      }
+
+      setState({ isLoading: false, error: result.error, data: null });
+      return null;
+    },
+    [hydrated, isAdmin],
+  );
 
   const reset = useCallback(() => setState(initialState), []);
 

--- a/src/features/users/hooks/useRegisterNotificationToken.ts
+++ b/src/features/users/hooks/useRegisterNotificationToken.ts
@@ -2,6 +2,8 @@
 
 import { useCallback, useState } from 'react';
 import { api } from '@lib/api';
+import { createForbiddenError } from '@features/auth/lib/adminAccess';
+import { useAuthSession } from '@features/auth/hooks/useAuthSession';
 import {
   skorifyEndpoints,
   type RegisterNotificationTokenPayload,
@@ -24,9 +26,15 @@ const initialState: UseRegisterNotificationTokenState = {
 
 export const useRegisterNotificationToken = () => {
   const [state, setState] = useState<UseRegisterNotificationTokenState>(initialState);
+  const { hydrated, isAdmin } = useAuthSession();
 
   const registerNotificationToken = useCallback(
     async (payload: RegisterNotificationTokenPayload): Promise<UserDto | null> => {
+      if (!hydrated || !isAdmin) {
+        setState({ isLoading: false, error: createForbiddenError(), data: null });
+        return null;
+      }
+
       setState({ isLoading: true, error: null, data: null });
 
       const result = await api.put<SkorifyEnvelope<UserDto>, RegisterNotificationTokenPayload>(
@@ -43,7 +51,7 @@ export const useRegisterNotificationToken = () => {
       setState({ isLoading: false, error: result.error, data: null });
       return null;
     },
-    [],
+    [hydrated, isAdmin],
   );
 
   const reset = useCallback(() => setState(initialState), []);

--- a/src/i18n/messages/en.json
+++ b/src/i18n/messages/en.json
@@ -573,6 +573,20 @@
     "description": "Looks like you've gone out of bounds. This page is not available.",
     "cta": "Back to home"
   },
+  "unauthorized": {
+    "branding": "SKORIFY",
+    "code": "401",
+    "title": "Unauthorized",
+    "description": "You need to log in to access this page.",
+    "cta": "Go to login"
+  },
+  "forbidden": {
+    "branding": "SKORIFY",
+    "code": "403",
+    "title": "Forbidden",
+    "description": "You are not authorized to view this page.",
+    "cta": "Back to home"
+  },
   "users": {
     "title": "Users",
     "subtitle": "Participant management",

--- a/src/i18n/messages/en.json
+++ b/src/i18n/messages/en.json
@@ -30,6 +30,8 @@
     "matches": "Matches",
     "matchesList": "Matches",
     "loadResults": "Load results",
+    "admin": "Admin",
+    "users": "Users",
     "tournaments": "Tournaments",
     "groups": "Groups",
     "profile": "Profile"

--- a/src/i18n/messages/es.json
+++ b/src/i18n/messages/es.json
@@ -24,13 +24,18 @@
     "playerAriaLabel": "Jugador pateando un balón hacia el arco",
     "goalAriaLabel": "Arco de fútbol"
   },
+  "admin": {
+    "title": "Panel de Administración",
+    "subtitle": "Gestiona usuarios, partidos, grupos y torneos",
+    "workingMessage": "En construcción: aquí los administradores podrán gestionar el contenido y la comunidad de Skorify."
+  },
   "nav": {
     "home": "Inicio",
     "predictions": "Predicciones",
     "matches": "Partidos",
     "matchesList": "Partidos",
     "loadResults": "Cargar resultados",
-    "admin": "Admin",
+    "admin": "Administrador",
     "users": "Usuarios",
     "tournaments": "Torneos",
     "groups": "Grupos",
@@ -571,6 +576,20 @@
     "code": "404",
     "title": "¡Fuera de Juego!",
     "description": "Parece que has salido de los límites del campo. Esta página no está disponible.",
+    "cta": "Volver al inicio"
+  },
+  "unauthorized": {
+    "branding": "SKORIFY",
+    "code": "401",
+    "title": "No Autorizado",
+    "description": "No tienes permisos para acceder a esta página.",
+    "cta": "Volver al inicio"
+  },
+  "forbidden": {
+    "branding": "SKORIFY",
+    "code": "403",
+    "title": "Prohibido",
+    "description": "No tienes autorización para ver esta página.",
     "cta": "Volver al inicio"
   },
   "users": {

--- a/src/i18n/messages/es.json
+++ b/src/i18n/messages/es.json
@@ -30,6 +30,8 @@
     "matches": "Partidos",
     "matchesList": "Partidos",
     "loadResults": "Cargar resultados",
+    "admin": "Admin",
+    "users": "Usuarios",
     "tournaments": "Torneos",
     "groups": "Grupos",
     "profile": "Perfil"

--- a/src/shared/components/organisms/DashboardNavbar.tsx
+++ b/src/shared/components/organisms/DashboardNavbar.tsx
@@ -12,10 +12,13 @@ import ListItemIcon from '@mui/material/ListItemIcon';
 import ListItemText from '@mui/material/ListItemText';
 import Typography from '@mui/material/Typography';
 import Divider from '@mui/material/Divider';
+import Box from '@mui/material/Box';
 import AccountCircleIcon from '@mui/icons-material/AccountCircle';
 import LogoutIcon from '@mui/icons-material/Logout';
+import WorkspacePremiumIcon from '@mui/icons-material/WorkspacePremium';
 import Link from 'next/link';
 import { tokens } from '@lib/theme/theme';
+import { useAuthSession } from '@features/auth/hooks/useAuthSession';
 import { useAuthStore } from '@features/auth/store/useAuthStore';
 
 const APPBAR_HEIGHT = 64;
@@ -27,7 +30,7 @@ type Props = {
 const DashboardNavbar = ({ username = 'Usuario' }: Props) => {
   const router = useRouter();
   const [anchor, setAnchor] = useState<null | HTMLElement>(null);
-  const session = useAuthStore((state) => state.session);
+  const { session, isAdmin } = useAuthSession();
   const logout = useAuthStore((state) => state.logout);
   const t = useTranslations('auth');
   const tNav = useTranslations('nav');
@@ -100,6 +103,32 @@ const DashboardNavbar = ({ username = 'Usuario' }: Props) => {
           >
             {profileName}
           </Typography>
+          {isAdmin ? (
+            <Box
+              component="span"
+              sx={{
+                display: 'inline-flex',
+                alignItems: 'center',
+                gap: 0.5,
+                px: 0.75,
+                py: 0.35,
+                borderRadius: 999,
+                bgcolor: `${tokens.primaryContainer}40`,
+                color: tokens.primary,
+                fontSize: '0.6875rem',
+                fontWeight: 800,
+                letterSpacing: '0.04em',
+                textTransform: 'uppercase',
+                lineHeight: 1,
+                whiteSpace: 'nowrap',
+              }}
+            >
+              <WorkspacePremiumIcon sx={{ fontSize: '0.9rem' }} />
+              <Box component="span" sx={{ display: { xs: 'none', md: 'inline' } }}>
+                {tNav('admin')}
+              </Box>
+            </Box>
+          ) : null}
         </IconButton>
 
         <Menu

--- a/src/shared/layouts/DrawerNavigationList.tsx
+++ b/src/shared/layouts/DrawerNavigationList.tsx
@@ -1,0 +1,259 @@
+'use client';
+
+import { type ReactNode } from 'react';
+import Link from 'next/link';
+import Box from '@mui/material/Box';
+import Collapse from '@mui/material/Collapse';
+import Divider from '@mui/material/Divider';
+import Drawer from '@mui/material/Drawer';
+import IconButton from '@mui/material/IconButton';
+import List from '@mui/material/List';
+import ListItem from '@mui/material/ListItem';
+import ListItemButton from '@mui/material/ListItemButton';
+import ListItemIcon from '@mui/material/ListItemIcon';
+import ListItemText from '@mui/material/ListItemText';
+import Tooltip from '@mui/material/Tooltip';
+import ChevronRightIcon from '@mui/icons-material/ChevronRight';
+import ExpandLessIcon from '@mui/icons-material/ExpandLess';
+import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
+import { tokens } from '@lib/theme/theme';
+import { activeChildKey, matchesPath, type DrawerItem } from './drawerItems';
+import { APPBAR_HEIGHT } from '@shared/components/organisms/DashboardNavbar';
+
+type Props = {
+  children: ReactNode;
+  items: ReadonlyArray<DrawerItem>;
+  open: boolean;
+  onToggleOpen: () => void;
+  pathname: string;
+  expandedKeys: ReadonlyArray<string>;
+  onToggleExpanded: (key: string) => void;
+  t: (key: string) => string;
+};
+
+const DrawerNavigationList = ({
+  children,
+  items,
+  open,
+  onToggleOpen,
+  pathname,
+  expandedKeys,
+  onToggleExpanded,
+  t,
+}: Props) => {
+  const drawerWidth = open ? 240 : 64;
+
+  return (
+    <>
+      <Drawer
+        variant="permanent"
+        sx={{
+          display: { xs: 'none', md: 'block' },
+          width: drawerWidth,
+          flexShrink: 0,
+          whiteSpace: 'nowrap',
+          boxSizing: 'border-box',
+          transition: (theme) =>
+            theme.transitions.create('width', {
+              easing: theme.transitions.easing.sharp,
+              duration: theme.transitions.duration.standard,
+            }),
+          '& .MuiDrawer-paper': {
+            width: drawerWidth,
+            top: `${APPBAR_HEIGHT}px`,
+            height: `calc(100% - ${APPBAR_HEIGHT}px)`,
+            transition: (theme) =>
+              theme.transitions.create('width', {
+                easing: theme.transitions.easing.sharp,
+                duration: theme.transitions.duration.standard,
+              }),
+            overflowX: 'hidden',
+            bgcolor: tokens.surfaceContainerLow,
+            border: 'none',
+            boxShadow: `1px 0 0 0 ${tokens.outlineVariant}26`,
+          },
+        }}
+      >
+        <List sx={{ px: 1, pt: 1.5, pb: 1 }}>
+          {items.map((item) => {
+            const { key, href, Icon, children: subItems } = item;
+            const hasChildren = !!subItems && subItems.length > 0;
+            const childKey = activeChildKey(item, pathname);
+            const active = hasChildren ? !!childKey : matchesPath(href, pathname);
+            const expanded = expandedKeys.includes(key);
+            const showChildren = hasChildren && open && expanded;
+
+            return (
+              <Box key={key}>
+                <ListItem disablePadding sx={{ mb: 0.5 }}>
+                  <Tooltip
+                    title={t(key)}
+                    placement="right"
+                    arrow
+                    disableHoverListener={open}
+                    disableFocusListener={open}
+                    disableTouchListener={open}
+                  >
+                    <ListItemButton
+                      {...(hasChildren && open
+                        ? { onClick: () => onToggleExpanded(key) }
+                        : { component: Link, href })}
+                      sx={{
+                        borderRadius: '0 8px 8px 0',
+                        minHeight: 44,
+                        px: 1.5,
+                        justifyContent: open ? 'flex-start' : 'center',
+                        opacity: active ? 1 : 0.6,
+                        borderLeft: `3px solid ${active ? tokens.primaryContainer : 'transparent'}`,
+                        background: active
+                          ? `linear-gradient(to right, ${tokens.primaryContainer}26, transparent)`
+                          : 'transparent',
+                        transition: 'opacity 150ms ease, background 150ms ease',
+                        '&:hover': {
+                          opacity: 1,
+                          background: active
+                            ? `linear-gradient(to right, ${tokens.primaryContainer}33, transparent)`
+                            : tokens.surfaceContainerHigh,
+                        },
+                      }}
+                    >
+                      <ListItemIcon
+                        sx={{ minWidth: 0, mr: open ? 1.5 : 0, justifyContent: 'center' }}
+                      >
+                        <Icon
+                          sx={{
+                            color: active ? tokens.primary : tokens.onSurfaceVariant,
+                            fontSize: '1.25rem',
+                          }}
+                        />
+                      </ListItemIcon>
+                      {open && (
+                        <ListItemText
+                          primary={t(key)}
+                          slotProps={{
+                            primary: {
+                              sx: {
+                                fontSize: '0.875rem',
+                                fontWeight: active ? 700 : 500,
+                                color: active ? tokens.primary : tokens.onSurface,
+                              },
+                            },
+                          }}
+                        />
+                      )}
+                      {hasChildren &&
+                        open &&
+                        (expanded ? (
+                          <ExpandLessIcon
+                            sx={{ color: tokens.onSurfaceVariant, fontSize: '1.125rem' }}
+                          />
+                        ) : (
+                          <ExpandMoreIcon
+                            sx={{ color: tokens.onSurfaceVariant, fontSize: '1.125rem' }}
+                          />
+                        ))}
+                    </ListItemButton>
+                  </Tooltip>
+                </ListItem>
+
+                {hasChildren && (
+                  <Collapse in={showChildren} timeout="auto" unmountOnExit>
+                    <List disablePadding sx={{ mb: 0.5 }}>
+                      {subItems.map(({ key: childKeyName, href: childHref, Icon: ChildIcon }) => {
+                        const isChildActive = childKey === childKeyName;
+                        return (
+                          <ListItem key={childKeyName} disablePadding sx={{ mb: 0.25 }}>
+                            <ListItemButton
+                              component={Link}
+                              href={childHref}
+                              sx={{
+                                borderRadius: '0 8px 8px 0',
+                                minHeight: 36,
+                                pl: 4.5,
+                                pr: 1.5,
+                                opacity: isChildActive ? 1 : 0.6,
+                                borderLeft: `3px solid ${isChildActive ? tokens.primaryContainer : 'transparent'}`,
+                                background: isChildActive
+                                  ? `linear-gradient(to right, ${tokens.primaryContainer}1A, transparent)`
+                                  : 'transparent',
+                                transition: 'opacity 150ms ease, background 150ms ease',
+                                '&:hover': {
+                                  opacity: 1,
+                                  background: isChildActive
+                                    ? `linear-gradient(to right, ${tokens.primaryContainer}26, transparent)`
+                                    : tokens.surfaceContainerHigh,
+                                },
+                              }}
+                            >
+                              <ListItemIcon sx={{ minWidth: 0, mr: 1.5 }}>
+                                <ChildIcon
+                                  sx={{
+                                    color: isChildActive ? tokens.primary : tokens.onSurfaceVariant,
+                                    fontSize: '1.125rem',
+                                  }}
+                                />
+                              </ListItemIcon>
+                              <ListItemText
+                                primary={t(childKeyName)}
+                                slotProps={{
+                                  primary: {
+                                    sx: {
+                                      fontSize: '0.8125rem',
+                                      fontWeight: isChildActive ? 700 : 500,
+                                      color: isChildActive ? tokens.primary : tokens.onSurface,
+                                    },
+                                  },
+                                }}
+                              />
+                            </ListItemButton>
+                          </ListItem>
+                        );
+                      })}
+                    </List>
+                  </Collapse>
+                )}
+              </Box>
+            );
+          })}
+        </List>
+
+        <Box sx={{ flexGrow: 1 }} />
+
+        <Divider sx={{ borderColor: `${tokens.outlineVariant}26` }} />
+        <Box
+          sx={{
+            display: 'flex',
+            justifyContent: open ? 'flex-end' : 'center',
+            px: 1,
+            py: 1,
+          }}
+        >
+          <IconButton onClick={onToggleOpen} size="small" aria-label="toggle drawer">
+            <ChevronRightIcon
+              sx={{
+                color: tokens.onSurfaceVariant,
+                fontSize: '1.25rem',
+                transform: open ? 'rotate(180deg)' : 'rotate(0deg)',
+                transition: 'transform 300ms ease',
+              }}
+            />
+          </IconButton>
+        </Box>
+      </Drawer>
+
+      <Box
+        component="main"
+        sx={{
+          flexGrow: 1,
+          overflow: 'auto',
+          mt: `${APPBAR_HEIGHT}px`,
+          pb: { xs: 8, md: 0 },
+        }}
+      >
+        {children}
+      </Box>
+    </>
+  );
+};
+
+export default DrawerNavigationList;

--- a/src/shared/layouts/DrawerShell.tsx
+++ b/src/shared/layouts/DrawerShell.tsx
@@ -1,297 +1,54 @@
 'use client';
 
-import { useState } from 'react';
-import { useTranslations } from 'next-intl';
+import { useMemo, useState } from 'react';
+import type { ReactNode } from 'react';
 import { usePathname } from 'next/navigation';
-import Box from '@mui/material/Box';
-import Collapse from '@mui/material/Collapse';
-import Divider from '@mui/material/Divider';
-import Drawer from '@mui/material/Drawer';
-import IconButton from '@mui/material/IconButton';
-import List from '@mui/material/List';
-import ListItem from '@mui/material/ListItem';
-import ListItemButton from '@mui/material/ListItemButton';
-import ListItemIcon from '@mui/material/ListItemIcon';
-import ListItemText from '@mui/material/ListItemText';
-import Tooltip from '@mui/material/Tooltip';
-import CalendarMonthIcon from '@mui/icons-material/CalendarMonth';
-import ChevronRightIcon from '@mui/icons-material/ChevronRight';
-import EmojiEventsIcon from '@mui/icons-material/EmojiEvents';
-import ExpandLessIcon from '@mui/icons-material/ExpandLess';
-import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
-import GroupIcon from '@mui/icons-material/Group';
-import HomeIcon from '@mui/icons-material/Home';
-import SportsSoccerIcon from '@mui/icons-material/SportsSoccer';
-import UploadFileIcon from '@mui/icons-material/UploadFile';
-import Link from 'next/link';
-import { tokens } from '@lib/theme/theme';
-import { APPBAR_HEIGHT } from '@shared/components/organisms/DashboardNavbar';
-import { type ComponentType, type ReactNode } from 'react';
-import { type SvgIconProps } from '@mui/material/SvgIcon';
+import { useTranslations } from 'next-intl';
+import { useAuthSession } from '@features/auth/hooks/useAuthSession';
+import DrawerNavigationList from './DrawerNavigationList';
+import { getDrawerItems, type DrawerRole, activeChildKey } from './drawerItems';
 
-const DRAWER_OPEN_WIDTH = 240;
-const DRAWER_CLOSED_WIDTH = 64;
 export const BOTTOM_NAV_HEIGHT = 64;
-
-type IconComponent = ComponentType<SvgIconProps>;
-type DrawerLeaf = { key: string; href: string; Icon: IconComponent };
-type DrawerItem = DrawerLeaf & { children?: ReadonlyArray<DrawerLeaf> };
-
-const DRAWER_ITEMS: ReadonlyArray<DrawerItem> = [
-  { key: 'home', href: '/home', Icon: HomeIcon },
-  {
-    key: 'matches',
-    href: '/matches',
-    Icon: CalendarMonthIcon,
-    children: [
-      { key: 'matchesList', href: '/matches', Icon: CalendarMonthIcon },
-      { key: 'predictions', href: '/predictions', Icon: SportsSoccerIcon },
-      { key: 'loadResults', href: '/matches/load-results', Icon: UploadFileIcon },
-    ],
-  },
-  { key: 'tournaments', href: '/tournaments', Icon: EmojiEventsIcon },
-  { key: 'groups', href: '/groups', Icon: GroupIcon },
-];
-
-const matchesPath = (href: string, pathname: string) =>
-  pathname === href || pathname.startsWith(`${href}/`);
-
-const activeChildKey = (item: DrawerItem, pathname: string): string | null => {
-  if (!item.children) return null;
-  const matching = item.children.filter((c) => matchesPath(c.href, pathname));
-  if (matching.length === 0) return null;
-  return matching.reduce((a, b) => (b.href.length > a.href.length ? b : a)).key;
-};
 
 const DrawerShell = ({ children }: { children: ReactNode }) => {
   const [open, setOpen] = useState(true);
+  const [manualExpandedKeys, setManualExpandedKeys] = useState<string[]>([]);
   const pathname = usePathname();
   const t = useTranslations('nav');
+  const { isAdmin } = useAuthSession();
+  const role: DrawerRole = isAdmin ? 'admin' : 'user';
 
-  const drawerWidth = open ? DRAWER_OPEN_WIDTH : DRAWER_CLOSED_WIDTH;
-
-  const initialExpanded = DRAWER_ITEMS.filter(
-    (item) => item.children && activeChildKey(item, pathname),
-  ).map((item) => item.key);
-  const [expandedKeys, setExpandedKeys] = useState<string[]>(initialExpanded);
+  const drawerItems = useMemo(() => getDrawerItems(role), [role]);
+  const activeExpandedKeys = useMemo(
+    () =>
+      drawerItems
+        .filter((item) => item.children && activeChildKey(item, pathname))
+        .map((item) => item.key),
+    [drawerItems, pathname],
+  );
+  const expandedKeys = useMemo(
+    () => Array.from(new Set([...manualExpandedKeys, ...activeExpandedKeys])),
+    [manualExpandedKeys, activeExpandedKeys],
+  );
 
   const toggleExpanded = (key: string) => {
-    setExpandedKeys((prev) =>
-      prev.includes(key) ? prev.filter((k) => k !== key) : [...prev, key],
+    setManualExpandedKeys((prev) =>
+      prev.includes(key) ? prev.filter((current) => current !== key) : [...prev, key],
     );
   };
 
   return (
-    <>
-      <Drawer
-        variant="permanent"
-        sx={{
-          display: { xs: 'none', md: 'block' },
-          width: drawerWidth,
-          flexShrink: 0,
-          whiteSpace: 'nowrap',
-          boxSizing: 'border-box',
-          transition: (theme) =>
-            theme.transitions.create('width', {
-              easing: theme.transitions.easing.sharp,
-              duration: theme.transitions.duration.standard,
-            }),
-          '& .MuiDrawer-paper': {
-            width: drawerWidth,
-            top: `${APPBAR_HEIGHT}px`,
-            height: `calc(100% - ${APPBAR_HEIGHT}px)`,
-            transition: (theme) =>
-              theme.transitions.create('width', {
-                easing: theme.transitions.easing.sharp,
-                duration: theme.transitions.duration.standard,
-              }),
-            overflowX: 'hidden',
-            bgcolor: tokens.surfaceContainerLow,
-            border: 'none',
-            boxShadow: `1px 0 0 0 ${tokens.outlineVariant}26`,
-          },
-        }}
-      >
-        <List sx={{ px: 1, pt: 1.5, pb: 1 }}>
-          {DRAWER_ITEMS.map((item) => {
-            const { key, href, Icon, children: subItems } = item;
-            const hasChildren = !!subItems && subItems.length > 0;
-            const childKey = activeChildKey(item, pathname);
-            const active = hasChildren ? !!childKey : matchesPath(href, pathname);
-            const expanded = expandedKeys.includes(key);
-
-            const showChildren = hasChildren && open && expanded;
-
-            return (
-              <Box key={key}>
-                <ListItem disablePadding sx={{ mb: 0.5 }}>
-                  <Tooltip
-                    title={t(key)}
-                    placement="right"
-                    arrow
-                    disableHoverListener={open}
-                    disableFocusListener={open}
-                    disableTouchListener={open}
-                  >
-                    <ListItemButton
-                      {...(hasChildren && open
-                        ? { onClick: () => toggleExpanded(key) }
-                        : { component: Link, href })}
-                      sx={{
-                        borderRadius: '0 8px 8px 0',
-                        minHeight: 44,
-                        px: 1.5,
-                        justifyContent: open ? 'flex-start' : 'center',
-                        opacity: active ? 1 : 0.6,
-                        borderLeft: `3px solid ${active ? tokens.primaryContainer : 'transparent'}`,
-                        background: active
-                          ? `linear-gradient(to right, ${tokens.primaryContainer}26, transparent)`
-                          : 'transparent',
-                        transition: 'opacity 150ms ease, background 150ms ease',
-                        '&:hover': {
-                          opacity: 1,
-                          background: active
-                            ? `linear-gradient(to right, ${tokens.primaryContainer}33, transparent)`
-                            : tokens.surfaceContainerHigh,
-                        },
-                      }}
-                    >
-                      <ListItemIcon
-                        sx={{ minWidth: 0, mr: open ? 1.5 : 0, justifyContent: 'center' }}
-                      >
-                        <Icon
-                          sx={{
-                            color: active ? tokens.primary : tokens.onSurfaceVariant,
-                            fontSize: '1.25rem',
-                          }}
-                        />
-                      </ListItemIcon>
-                      {open && (
-                        <ListItemText
-                          primary={t(key)}
-                          slotProps={{
-                            primary: {
-                              sx: {
-                                fontSize: '0.875rem',
-                                fontWeight: active ? 700 : 500,
-                                color: active ? tokens.primary : tokens.onSurface,
-                              },
-                            },
-                          }}
-                        />
-                      )}
-                      {hasChildren &&
-                        open &&
-                        (expanded ? (
-                          <ExpandLessIcon
-                            sx={{ color: tokens.onSurfaceVariant, fontSize: '1.125rem' }}
-                          />
-                        ) : (
-                          <ExpandMoreIcon
-                            sx={{ color: tokens.onSurfaceVariant, fontSize: '1.125rem' }}
-                          />
-                        ))}
-                    </ListItemButton>
-                  </Tooltip>
-                </ListItem>
-
-                {hasChildren && (
-                  <Collapse in={showChildren} timeout="auto" unmountOnExit>
-                    <List disablePadding sx={{ mb: 0.5 }}>
-                      {subItems.map(({ key: childKeyName, href: childHref, Icon: ChildIcon }) => {
-                        const isChildActive = childKey === childKeyName;
-                        return (
-                          <ListItem key={childKeyName} disablePadding sx={{ mb: 0.25 }}>
-                            <ListItemButton
-                              component={Link}
-                              href={childHref}
-                              sx={{
-                                borderRadius: '0 8px 8px 0',
-                                minHeight: 36,
-                                pl: 4.5,
-                                pr: 1.5,
-                                opacity: isChildActive ? 1 : 0.6,
-                                borderLeft: `3px solid ${isChildActive ? tokens.primaryContainer : 'transparent'}`,
-                                background: isChildActive
-                                  ? `linear-gradient(to right, ${tokens.primaryContainer}1A, transparent)`
-                                  : 'transparent',
-                                transition: 'opacity 150ms ease, background 150ms ease',
-                                '&:hover': {
-                                  opacity: 1,
-                                  background: isChildActive
-                                    ? `linear-gradient(to right, ${tokens.primaryContainer}26, transparent)`
-                                    : tokens.surfaceContainerHigh,
-                                },
-                              }}
-                            >
-                              <ListItemIcon sx={{ minWidth: 0, mr: 1.5 }}>
-                                <ChildIcon
-                                  sx={{
-                                    color: isChildActive ? tokens.primary : tokens.onSurfaceVariant,
-                                    fontSize: '1.125rem',
-                                  }}
-                                />
-                              </ListItemIcon>
-                              <ListItemText
-                                primary={t(childKeyName)}
-                                slotProps={{
-                                  primary: {
-                                    sx: {
-                                      fontSize: '0.8125rem',
-                                      fontWeight: isChildActive ? 700 : 500,
-                                      color: isChildActive ? tokens.primary : tokens.onSurface,
-                                    },
-                                  },
-                                }}
-                              />
-                            </ListItemButton>
-                          </ListItem>
-                        );
-                      })}
-                    </List>
-                  </Collapse>
-                )}
-              </Box>
-            );
-          })}
-        </List>
-
-        <Box sx={{ flexGrow: 1 }} />
-
-        <Divider sx={{ borderColor: `${tokens.outlineVariant}26` }} />
-        <Box
-          sx={{
-            display: 'flex',
-            justifyContent: open ? 'flex-end' : 'center',
-            px: 1,
-            py: 1,
-          }}
-        >
-          <IconButton onClick={() => setOpen(!open)} size="small" aria-label="toggle drawer">
-            <ChevronRightIcon
-              sx={{
-                color: tokens.onSurfaceVariant,
-                fontSize: '1.25rem',
-                transform: open ? 'rotate(180deg)' : 'rotate(0deg)',
-                transition: 'transform 300ms ease',
-              }}
-            />
-          </IconButton>
-        </Box>
-      </Drawer>
-
-      <Box
-        component="main"
-        sx={{
-          flexGrow: 1,
-          overflow: 'auto',
-          mt: `${APPBAR_HEIGHT}px`,
-          pb: { xs: `${BOTTOM_NAV_HEIGHT}px`, md: 0 },
-        }}
-      >
-        {children}
-      </Box>
-    </>
+    <DrawerNavigationList
+      items={drawerItems}
+      open={open}
+      onToggleOpen={() => setOpen((current) => !current)}
+      pathname={pathname}
+      expandedKeys={expandedKeys}
+      onToggleExpanded={toggleExpanded}
+      t={t}
+    >
+      {children}
+    </DrawerNavigationList>
   );
 };
 

--- a/src/shared/layouts/drawerItems.ts
+++ b/src/shared/layouts/drawerItems.ts
@@ -1,0 +1,51 @@
+import type { ComponentType } from 'react';
+import type { SvgIconProps } from '@mui/material/SvgIcon';
+import CalendarMonthIcon from '@mui/icons-material/CalendarMonth';
+import EmojiEventsIcon from '@mui/icons-material/EmojiEvents';
+import GroupIcon from '@mui/icons-material/Group';
+import HomeIcon from '@mui/icons-material/Home';
+import SportsSoccerIcon from '@mui/icons-material/SportsSoccer';
+import UploadFileIcon from '@mui/icons-material/UploadFile';
+import WorkspacePremiumIcon from '@mui/icons-material/WorkspacePremium';
+
+type IconComponent = ComponentType<SvgIconProps>;
+
+export type DrawerLeaf = { key: string; href: string; Icon: IconComponent };
+export type DrawerItem = DrawerLeaf & { children?: ReadonlyArray<DrawerLeaf> };
+export type DrawerRole = 'user' | 'admin';
+
+const baseItems: ReadonlyArray<DrawerItem> = [
+  { key: 'home', href: '/home', Icon: HomeIcon },
+  {
+    key: 'matches',
+    href: '/matches',
+    Icon: CalendarMonthIcon,
+    children: [
+      { key: 'matchesList', href: '/matches', Icon: CalendarMonthIcon },
+      { key: 'predictions', href: '/predictions', Icon: SportsSoccerIcon },
+    ],
+  },
+  { key: 'tournaments', href: '/tournaments', Icon: EmojiEventsIcon },
+  { key: 'groups', href: '/groups', Icon: GroupIcon },
+];
+
+const adminItems: ReadonlyArray<DrawerItem> = [
+  { key: 'admin', href: '/admin', Icon: WorkspacePremiumIcon },
+  { key: 'users', href: '/users', Icon: GroupIcon },
+  { key: 'loadResults', href: '/matches/load-results', Icon: UploadFileIcon },
+];
+
+export const getDrawerItems = (role: DrawerRole = 'user'): ReadonlyArray<DrawerItem> =>
+  role === 'admin' ? [...baseItems, ...adminItems] : baseItems;
+
+const excludesPrefixMatch = (pathname: string) => pathname === '/matches/load-results';
+
+export const matchesPath = (href: string, pathname: string) =>
+  pathname === href || (pathname.startsWith(`${href}/`) && !excludesPrefixMatch(pathname));
+
+export const activeChildKey = (item: DrawerItem, pathname: string): string | null => {
+  if (!item.children) return null;
+  const matching = item.children.filter((c) => matchesPath(c.href, pathname));
+  if (matching.length === 0) return null;
+  return matching.reduce((a, b) => (b.href.length > a.href.length ? b : a)).key;
+};


### PR DESCRIPTION
Este PR resuelve 2 issues: 

- [Control de acceso por rol (admin vs usuario)](https://github.com/orgs/aws-ug-manizales/projects/8/views/1?pane=issue&itemId=173038755&issue=aws-ug-manizales%7CSkorify_Frontend%7C13)
- [Layout y navegación del panel de administrador](https://github.com/orgs/aws-ug-manizales/projects/8/views/1?pane=issue&itemId=173038755&issue=aws-ug-manizales%7CSkorify_Frontend%7C13)

**Incluye:**
- refactorización de la pantalla de login/register para aplicar atomic design
- creación de la ruta /admin protegida por rol admin
- creación de sistema de mock para usuarios y roles
- drawer mejorado con links a secciones: partidos, grupos, resultados, y funciones de gestion del administrador
- indicador visual del nombre del admin logueado
- componente "AdminGuard" que verifica rol, llamado "RequireAdmin"
- se verifico que el menú de admin no aparece para usuarios regulares
- las llamadas a endpoints de admin incluyen verificación
- redirige a 403 cuando un usuario normal intenta ingresar a una vista de administrador