### PR TITLE
feat: vista de partidos jugados con marcador, predicciones y aciertos…

### DIFF
--- a/src/app/(dashboard)/groups/[id]/results/page.tsx
+++ b/src/app/(dashboard)/groups/[id]/results/page.tsx
@@ -1,0 +1,8 @@
+import GroupResultsView from '@features/groups/components/organisms/GroupResultsView';
+
+export const generateStaticParams = () => [{ id: '_' }];
+
+export default async function GroupResultsPage({ params }: { params: Promise<{ id: string }> }) {
+  const resolvedParams = await params;
+  return <GroupResultsView groupId={resolvedParams.id} />;
+}

--- a/src/app/(dashboard)/results/page.tsx
+++ b/src/app/(dashboard)/results/page.tsx
@@ -1,0 +1,116 @@
+'use client';
+
+import Box from '@mui/material/Box';
+import Typography from '@mui/material/Typography';
+import { tokens } from '@lib/theme/theme';
+import { useMatchesList } from '@features/matches/hooks/useMatchesList';
+import FinishedMatchCard from '@features/matches/components/molecules/FinishedMatchCard';
+import { formatKickoff } from '@features/matches/utils/formatKickoff';
+import { useLocale, useTranslations } from 'next-intl';
+import { useMemo } from 'react';
+
+// Función para traducciones
+const getTournamentLabel = (key: string, t: (key: string) => string) => {
+  try {
+    return t(key);
+  } catch {
+    return key;
+  }
+};
+
+const getStageLabel = (key: string, t: (key: string) => string) => {
+  try {
+    return t(key);
+  } catch {
+    return key;
+  }
+};
+
+export default function ResultsPage() {
+  const t = useTranslations('results');
+  const m = useTranslations('matches');
+  const locale = useLocale();
+
+  // Inicializar con filtro de partidos finalizados
+  const { items, loading, total } = useMatchesList(20, 'filterFinished');
+
+  // Filtrar solo partidos finalizados y ordenar por fecha más reciente
+  const finishedMatches = useMemo(() => {
+    // Filtrar solo partidos finalizados y ordenar por kickoffAt descendente
+    return [...items]
+      .filter((match) => match.status === 'finished')
+      .sort((a, b) => new Date(b.kickoffAt).getTime() - new Date(a.kickoffAt).getTime());
+  }, [items]);
+
+  return (
+    <Box sx={{ p: { xs: 3, md: 4 }, maxWidth: 1200, mx: 'auto' }}>
+      <Typography
+        variant="h4"
+        component="h1"
+        sx={{
+          mb: 1,
+          fontWeight: 800,
+          fontSize: '2rem',
+          letterSpacing: '-0.02em',
+        }}
+      >
+        {t('title', { defaultValue: 'Resultados' })}
+      </Typography>
+
+      <Typography
+        sx={{
+          mb: 4,
+          color: tokens.onSurfaceVariant,
+          fontSize: '0.875rem',
+        }}
+      >
+        {t('subtitle', {
+          count: finishedMatches.length,
+          defaultValue: `Historial de partidos finalizados y predicciones (${finishedMatches.length})`,
+        })}
+      </Typography>
+
+      {loading ? (
+        <Box
+          sx={{
+            py: 8,
+            textAlign: 'center',
+            color: tokens.onSurfaceVariant,
+          }}
+        >
+          <Typography>{t('loading', { defaultValue: 'Cargando resultados...' })}</Typography>
+        </Box>
+      ) : total === 0 || finishedMatches.length === 0 ? (
+        <Box
+          sx={{
+            py: 8,
+            textAlign: 'center',
+            color: tokens.onSurfaceVariant,
+          }}
+        >
+          <Typography>
+            {t('noMatches', { defaultValue: 'Aún no hay partidos finalizados.' })}
+          </Typography>
+        </Box>
+      ) : (
+        <Box sx={{ display: 'grid', gap: 3, gridTemplateColumns: { xs: '1fr', md: '1fr 1fr' } }}>
+          {finishedMatches.map((match) => (
+            <FinishedMatchCard
+              key={match.id}
+              match={match}
+              tournamentLabel={getTournamentLabel(match.tournamentKey, m)}
+              stageLabel={getStageLabel(match.stageKey, m)}
+              kickoffLabel={formatKickoff(match.kickoffAt, locale)}
+              vsLabel={m('vs')}
+              predictionLabel={m('predictionLabel', { defaultValue: 'Tu predicción' })}
+              exactLabel={t('exact', { defaultValue: 'Acierto exacto' })}
+              partialLabel={t('partial', { defaultValue: 'Acierto parcial' })}
+              wrongLabel={t('wrong', { defaultValue: 'Incorrecto' })}
+              noPredictionLabel={t('noPrediction', { defaultValue: 'Sin predicción' })}
+            />
+          ))}
+        </Box>
+      )}
+    </Box>
+  );
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -5,6 +5,7 @@ import { getLocale, getMessages, getTranslations } from 'next-intl/server';
 import ThemeRegistry from '@/lib/theme/ThemeRegistry';
 import { NotificationProvider } from '@shared/notifications';
 import './globals.scss';
+// Trigger translation reload
 
 const lexend = Lexend({
   subsets: ['latin'],
@@ -26,7 +27,7 @@ const RootLayout = async ({ children }: Readonly<{ children: React.ReactNode }>)
   const messages = await getMessages();
 
   return (
-    <html lang={locale} className={lexend.variable}>
+    <html lang={locale} className={lexend.variable} suppressHydrationWarning>
       <body>
         <ThemeRegistry>
           <NextIntlClientProvider locale={locale} messages={messages}>

--- a/src/features/groups/components/organisms/GroupDetail.tsx
+++ b/src/features/groups/components/organisms/GroupDetail.tsx
@@ -10,7 +10,9 @@ import ChevronRightIcon from '@mui/icons-material/ChevronRight';
 import CloseIcon from '@mui/icons-material/Close';
 import SportsSoccerIcon from '@mui/icons-material/SportsSoccer';
 import WarningAmberIcon from '@mui/icons-material/WarningAmber';
-import { useTranslations } from 'next-intl';
+import Tab from '@mui/material/Tab';
+import Tabs from '@mui/material/Tabs';
+import { useTranslations, useLocale } from 'next-intl';
 import { tokens } from '@lib/theme/theme';
 import AppButton from '@shared/components/atoms/AppButton';
 import AppCard from '@shared/components/molecules/AppCard';
@@ -23,8 +25,27 @@ import MemberList from './MemberList';
 import ShareGroupDialog from './ShareGroupDialog';
 import StandingsTable from './StandingsTable';
 import TopPodium from '../molecules/TopPodium';
+import { useMatchesList } from '@features/matches/hooks/useMatchesList';
+import FinishedMatchCard from '@features/matches/components/molecules/FinishedMatchCard';
+import { formatKickoff } from '@features/matches/utils/formatKickoff';
 
 const MOCK_CURRENT_USER_ID = 'mock-admin-id';
+
+const getTournamentLabel = (key: string, t: (key: string) => string) => {
+  try {
+    return t(key);
+  } catch {
+    return key;
+  }
+};
+
+const getStageLabel = (key: string, t: (key: string) => string) => {
+  try {
+    return t(key);
+  } catch {
+    return key;
+  }
+};
 
 interface GroupDetailProps {
   groupId: string;
@@ -33,8 +54,23 @@ interface GroupDetailProps {
 const GroupDetail = ({ groupId }: GroupDetailProps) => {
   const t = useTranslations('groups');
   const tCommon = useTranslations('common');
+  const m = useTranslations('matches');
+  const tResults = useTranslations('results');
+  const locale = useLocale();
+
+  const [activeTab, setActiveTab] = useState<'standings' | 'results'>('standings');
+
   const { data, isLoading, error, refetch } = useGroupDetail(groupId);
   const session = useAuthStore((s) => s.session);
+
+  const { items: matchItems, loading: loadingResults } = useMatchesList(20, 'filterFinished');
+
+  const finishedMatches = useMemo(() => {
+    return [...matchItems]
+      .filter((match) => match.status === 'finished')
+      .sort((a, b) => new Date(b.kickoffAt).getTime() - new Date(a.kickoffAt).getTime());
+  }, [matchItems]);
+
   const [shareOpen, setShareOpen] = useState(false);
   const [successOpen, setSuccessOpen] = useState(() => {
     if (typeof window === 'undefined') return false;
@@ -134,66 +170,138 @@ const GroupDetail = ({ groupId }: GroupDetailProps) => {
           }}
         >
           <Box sx={{ display: 'flex', flexDirection: 'column', gap: 3 }}>
-            <TopPodium
-              standings={data.standings}
-              previousStandings={mockedPreviousStandings}
-              currentUserId={currentUserId}
-              pointsLabel={t('pointsLabel')}
-            />
-            <StandingsTable
-              standings={data.standings}
-              previousStandings={mockedPreviousStandings}
-              currentUserId={currentUserId}
-              onRefresh={refetch}
-              isRefreshing={isLoading}
-            />
+            <Tabs
+              value={activeTab}
+              onChange={(_e, val) => setActiveTab(val)}
+              sx={{
+                borderBottom: `1px solid ${tokens.outlineVariant}26`,
+                '& .MuiTabs-indicator': {
+                  bgcolor: tokens.primary,
+                  height: 3,
+                  borderRadius: '3px 3px 0 0',
+                },
+                '& .MuiTab-root': {
+                  fontWeight: 800,
+                  fontSize: '0.875rem',
+                  textTransform: 'uppercase',
+                  letterSpacing: '0.05em',
+                  color: tokens.onSurfaceVariant,
+                  minWidth: 120,
+                  pb: 1.5,
+                  '&.Mui-selected': {
+                    color: tokens.primary,
+                  },
+                },
+              }}
+            >
+              <Tab value="standings" label={t('standingsTitle') || 'Clasificación'} />
+              <Tab value="results" label={t('finishedMatchesTitle') || 'Resultados'} />
+            </Tabs>
+
+            {activeTab === 'standings' && (
+              <Box sx={{ display: 'flex', flexDirection: 'column', gap: 3 }}>
+                <TopPodium
+                  standings={data.standings}
+                  previousStandings={mockedPreviousStandings}
+                  currentUserId={currentUserId}
+                  pointsLabel={t('pointsLabel')}
+                />
+                <StandingsTable
+                  standings={data.standings}
+                  previousStandings={mockedPreviousStandings}
+                  currentUserId={currentUserId}
+                  onRefresh={refetch}
+                  isRefreshing={isLoading}
+                />
+              </Box>
+            )}
+
+            {activeTab === 'results' && (
+              <Box sx={{ display: 'flex', flexDirection: 'column', gap: 3 }}>
+                {loadingResults ? (
+                  <Box sx={{ p: 4, textAlign: 'center' }}>
+                    <Typography variant="body1" sx={{ color: tokens.onSurfaceVariant }}>
+                      {tResults('loading', { defaultValue: 'Cargando resultados...' })}
+                    </Typography>
+                  </Box>
+                ) : finishedMatches.length === 0 ? (
+                  <Box sx={{ p: 4, textAlign: 'center' }}>
+                    <Typography variant="body1" sx={{ color: tokens.onSurfaceVariant }}>
+                      {tResults('noMatches', { defaultValue: 'Aún no hay partidos finalizados.' })}
+                    </Typography>
+                  </Box>
+                ) : (
+                  <Box sx={{ display: 'grid', gap: 3, gridTemplateColumns: '1fr' }}>
+                    {finishedMatches.map((match) => (
+                      <FinishedMatchCard
+                        key={match.id}
+                        match={match}
+                        tournamentLabel={getTournamentLabel(match.tournamentKey, m)}
+                        stageLabel={getStageLabel(match.stageKey, m)}
+                        kickoffLabel={formatKickoff(match.kickoffAt, locale)}
+                        vsLabel={m('vs')}
+                        predictionLabel={m('predictionLabel', { defaultValue: 'Tu predicción' })}
+                        exactLabel={tResults('exact', { defaultValue: 'Acierto exacto' })}
+                        partialLabel={tResults('partial', { defaultValue: 'Acierto parcial' })}
+                        wrongLabel={tResults('wrong', { defaultValue: 'Incorrecto' })}
+                        noPredictionLabel={tResults('noPrediction', {
+                          defaultValue: 'Sin predicción',
+                        })}
+                      />
+                    ))}
+                  </Box>
+                )}
+              </Box>
+            )}
           </Box>
 
           <Box sx={{ display: 'flex', flexDirection: 'column', gap: 3 }}>
             <MemberList members={data.members} currentUserId={currentUserId} />
-            <AppCard variant="interactive" href="/predictions">
-              <Box
-                sx={{
-                  display: 'flex',
-                  alignItems: 'center',
-                  gap: 2,
-                  p: { xs: 2, md: 2.5 },
-                }}
-              >
+            <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
+              <AppCard variant="interactive" href="/predictions">
                 <Box
                   sx={{
                     display: 'flex',
                     alignItems: 'center',
-                    justifyContent: 'center',
-                    width: 48,
-                    height: 48,
-                    borderRadius: '50%',
-                    bgcolor: `${tokens.primary}1A`,
-                    flexShrink: 0,
+                    gap: 2,
+                    p: { xs: 2, md: 2.5 },
                   }}
                 >
-                  <SportsSoccerIcon sx={{ color: tokens.primary, fontSize: 24 }} />
-                </Box>
-                <Box sx={{ flex: 1, minWidth: 0 }}>
-                  <Typography
+                  <Box
                     sx={{
-                      color: tokens.onSurface,
-                      fontWeight: 800,
-                      fontSize: { xs: '0.9375rem', md: '1rem' },
-                      textTransform: 'uppercase',
-                      letterSpacing: '0.04em',
-                      lineHeight: 1.2,
+                      display: 'flex',
+                      alignItems: 'center',
+                      justifyContent: 'center',
+                      width: 48,
+                      height: 48,
+                      borderRadius: '50%',
+                      bgcolor: `${tokens.primary}1A`,
+                      flexShrink: 0,
                     }}
                   >
-                    {t('predictionsCardTitle')}
-                  </Typography>
-                  <Typography variant="body2" sx={{ color: tokens.onSurfaceVariant, mt: 0.5 }}>
-                    {t('predictionsCardSubtitle')}
-                  </Typography>
+                    <SportsSoccerIcon sx={{ color: tokens.primary, fontSize: 24 }} />
+                  </Box>
+                  <Box sx={{ flex: 1, minWidth: 0 }}>
+                    <Typography
+                      sx={{
+                        color: tokens.onSurface,
+                        fontWeight: 800,
+                        fontSize: { xs: '0.9375rem', md: '1rem' },
+                        textTransform: 'uppercase',
+                        letterSpacing: '0.04em',
+                        lineHeight: 1.2,
+                      }}
+                    >
+                      {t('predictionsCardTitle')}
+                    </Typography>
+                    <Typography variant="body2" sx={{ color: tokens.onSurfaceVariant, mt: 0.5 }}>
+                      {t('predictionsCardSubtitle')}
+                    </Typography>
+                  </Box>
+                  <ChevronRightIcon sx={{ color: tokens.onSurfaceVariant, fontSize: 24 }} />
                 </Box>
-                <ChevronRightIcon sx={{ color: tokens.onSurfaceVariant, fontSize: 24 }} />
-              </Box>
-            </AppCard>
+              </AppCard>
+            </Box>
           </Box>
         </Box>
       </Box>

--- a/src/features/groups/components/organisms/GroupResultsView.tsx
+++ b/src/features/groups/components/organisms/GroupResultsView.tsx
@@ -1,0 +1,104 @@
+'use client';
+
+import Box from '@mui/material/Box';
+import Typography from '@mui/material/Typography';
+import { useLocale, useTranslations } from 'next-intl';
+import { tokens } from '@lib/theme/theme';
+import AppButton from '@shared/components/atoms/AppButton';
+import ArrowBackIcon from '@mui/icons-material/ArrowBack';
+import { useRouter } from 'next/navigation';
+import { useMatchesList } from '@features/matches/hooks/useMatchesList';
+import FinishedMatchCard from '@features/matches/components/molecules/FinishedMatchCard';
+import { formatKickoff } from '@features/matches/utils/formatKickoff';
+import PageHeader from '@shared/components/molecules/PageHeader';
+import { useMemo } from 'react';
+
+interface GroupResultsViewProps {
+  groupId: string;
+}
+
+const getTournamentLabel = (key: string, t: (key: string) => string) => {
+  try {
+    return t(key);
+  } catch {
+    return key;
+  }
+};
+
+const getStageLabel = (key: string, t: (key: string) => string) => {
+  try {
+    return t(key);
+  } catch {
+    return key;
+  }
+};
+
+const GroupResultsView = ({ groupId }: GroupResultsViewProps) => {
+  const g = useTranslations('groups');
+  const t = useTranslations('results');
+  const m = useTranslations('matches');
+  const locale = useLocale();
+  const router = useRouter();
+
+  // Inicializar con filtro de partidos finalizados
+  const { items, loading } = useMatchesList(20, 'filterFinished');
+
+  // Filtrar solo partidos finalizados y ordenar por fecha más reciente
+  const finishedMatches = useMemo(() => {
+    return [...items]
+      .filter((match) => match.status === 'finished')
+      .sort((a, b) => new Date(b.kickoffAt).getTime() - new Date(a.kickoffAt).getTime());
+  }, [items]);
+
+  return (
+    <Box sx={{ p: { xs: 2, md: 3 }, maxWidth: 800, mx: 'auto' }}>
+      <AppButton
+        variant="tertiary"
+        onClick={() => router.push(`/groups/${groupId}`)}
+        sx={{ mb: 2, color: tokens.onSurfaceVariant }}
+      >
+        <ArrowBackIcon sx={{ mr: 1, fontSize: 20 }} />
+        {g('backToGroup') || 'Volver al grupo'}
+      </AppButton>
+
+      <PageHeader
+        title={g('finishedMatchesTitle') || 'Resultados'}
+        subtitle={g('finishedMatchesSubtitle') || 'Partidos finalizados y predicciones'}
+      />
+
+      {loading ? (
+        <Box sx={{ p: 4, textAlign: 'center' }}>
+          <Typography variant="body1" sx={{ color: tokens.onSurfaceVariant }}>
+            {t('loading', { defaultValue: 'Cargando resultados...' })}
+          </Typography>
+        </Box>
+      ) : finishedMatches.length === 0 ? (
+        <Box sx={{ p: 4, textAlign: 'center' }}>
+          <Typography variant="body1" sx={{ color: tokens.onSurfaceVariant }}>
+            {t('noMatches', { defaultValue: 'Aún no hay partidos finalizados.' })}
+          </Typography>
+        </Box>
+      ) : (
+        <Box sx={{ display: 'grid', gap: 3, gridTemplateColumns: '1fr' }}>
+          {finishedMatches.map((match) => (
+            <FinishedMatchCard
+              key={match.id}
+              match={match}
+              tournamentLabel={getTournamentLabel(match.tournamentKey, m)}
+              stageLabel={getStageLabel(match.stageKey, m)}
+              kickoffLabel={formatKickoff(match.kickoffAt, locale)}
+              vsLabel={m('vs')}
+              predictionLabel={m('predictionLabel', { defaultValue: 'Tu predicción' })}
+              exactLabel={t('exact', { defaultValue: 'Acierto exacto' })}
+              partialLabel={t('partial', { defaultValue: 'Acierto parcial' })}
+              wrongLabel={t('wrong', { defaultValue: 'Incorrecto' })}
+              noPredictionLabel={t('noPrediction', { defaultValue: 'Sin predicción' })}
+            />
+          ))}
+        </Box>
+      )}
+    </Box>
+  );
+};
+
+export default GroupResultsView;

--- a/src/features/matches/components/molecules/FinishedMatchCard.tsx
+++ b/src/features/matches/components/molecules/FinishedMatchCard.tsx
@@ -1,0 +1,296 @@
+'use client';
+
+import Box from '@mui/material/Box';
+import Typography from '@mui/material/Typography';
+import CheckCircleIcon from '@mui/icons-material/CheckCircle';
+import { useTranslations } from 'next-intl';
+import { tokens } from '@lib/theme/theme';
+import type { Match } from '../../types';
+import TeamBlock from '../atoms/TeamBlock';
+import {
+  evaluatePrediction,
+  getPredictionResultColor,
+  getPredictionResultIcon,
+  calculatePredictionPoints,
+  PredictionResult,
+} from '../../utils/predictionEvaluator';
+
+type Props = {
+  match: Match;
+  tournamentLabel: string;
+  stageLabel: string;
+  kickoffLabel: string;
+  vsLabel: string;
+  predictionLabel: string;
+  exactLabel: string;
+  partialLabel: string;
+  wrongLabel: string;
+  noPredictionLabel: string;
+  onViewDetails?: (match: Match) => void;
+};
+
+const FinishedMatchCard = ({
+  match,
+  tournamentLabel,
+  stageLabel,
+  kickoffLabel,
+  vsLabel,
+  predictionLabel,
+  exactLabel,
+  partialLabel,
+  wrongLabel,
+  noPredictionLabel,
+  onViewDetails,
+}: Props) => {
+  const t = useTranslations('results');
+
+  const predictionResult: PredictionResult = match.score
+    ? evaluatePrediction(match.score, match.prediction)
+    : 'no-prediction';
+
+  const resultColor = getPredictionResultColor(predictionResult);
+  const resultIcon = getPredictionResultIcon(predictionResult);
+
+  const getSafeLabel = (res: PredictionResult) => {
+    switch (res) {
+      case 'exact':
+        return exactLabel || 'Acierto exacto';
+      case 'partial':
+        return partialLabel || 'Acierto parcial';
+      case 'wrong':
+        return wrongLabel || 'Incorrecto';
+      case 'no-prediction':
+      default:
+        return noPredictionLabel || 'Sin predicción';
+    }
+  };
+
+  const resultLabel = getSafeLabel(predictionResult);
+
+  // Calcular puntos obtenidos
+  const totalPoints =
+    match.score && match.prediction
+      ? calculatePredictionPoints(match.score, match.prediction).totalPoints
+      : 0;
+
+  return (
+    <Box
+      sx={{
+        bgcolor: tokens.surfaceContainerLow,
+        borderRadius: '8px',
+        p: 3,
+        position: 'relative',
+        overflow: 'hidden',
+        display: 'flex',
+        flexDirection: 'column',
+        gap: 2.25,
+        transition: 'all 250ms cubic-bezier(0.4, 0, 0.2, 1)',
+        border: '1px solid transparent',
+        '&:hover': {
+          boxShadow: tokens.glowHover,
+          borderColor: `${tokens.primary}26`,
+        },
+      }}
+    >
+      {/* Badge de estado finalizado */}
+      <Box
+        sx={{
+          position: 'absolute',
+          top: 12,
+          right: 12,
+          display: 'flex',
+          alignItems: 'center',
+          gap: 0.5,
+          bgcolor: `${tokens.success}1A`,
+          color: tokens.success,
+          px: 1.5,
+          py: 0.5,
+          borderRadius: '4px',
+          fontSize: '0.625rem',
+          fontWeight: 700,
+          textTransform: 'uppercase',
+          letterSpacing: '0.08em',
+        }}
+      >
+        <CheckCircleIcon sx={{ fontSize: '0.75rem' }} />
+        Finalizado
+      </Box>
+
+      {/* Encabezado del partido */}
+      <Box>
+        <Typography
+          sx={{
+            fontSize: '0.625rem',
+            color: tokens.onSurfaceVariant,
+            textTransform: 'uppercase',
+            letterSpacing: '0.12em',
+            fontWeight: 700,
+            mb: 0.5,
+          }}
+        >
+          {tournamentLabel} • {stageLabel}
+        </Typography>
+        <Typography sx={{ color: tokens.onSurfaceVariant, fontSize: '0.75rem' }}>
+          {kickoffLabel}
+        </Typography>
+      </Box>
+
+      {/* Equipos y marcador */}
+      <Box
+        sx={{
+          display: 'grid',
+          gridTemplateColumns: '1fr auto 1fr',
+          alignItems: 'center',
+          gap: 1,
+        }}
+      >
+        <TeamBlock name={match.homeTeam.name} code={match.homeTeam.code} />
+        <Box
+          sx={{
+            display: 'flex',
+            flexDirection: 'column',
+            alignItems: 'center',
+            gap: 0.5,
+          }}
+        >
+          <Typography
+            sx={{
+              fontWeight: 900,
+              fontSize: '1.5rem',
+              color: tokens.onSurface,
+              lineHeight: 1,
+            }}
+          >
+            {match.score?.home ?? 0} - {match.score?.away ?? 0}
+          </Typography>
+        </Box>
+        <TeamBlock name={match.awayTeam.name} code={match.awayTeam.code} align="right" />
+      </Box>
+
+      {/* Fila de predicción del usuario y estado del resultado */}
+      <Box
+        sx={{
+          display: 'flex',
+          flexDirection: { xs: 'column', sm: 'row' },
+          gap: 1.25,
+          alignItems: { xs: 'stretch', sm: 'center' },
+          justifyContent: 'space-between',
+        }}
+      >
+        <Box
+          sx={{
+            display: 'flex',
+            alignItems: 'center',
+            flexWrap: 'wrap',
+            gap: 1.25,
+          }}
+        >
+          {/* 1. Badge de Predicción: [TU PREDICCIÓN 0 - 0] */}
+          {match.prediction ? (
+            <Box
+              sx={{
+                display: 'flex',
+                alignItems: 'center',
+                gap: 1,
+                bgcolor: `${tokens.primary}0F`,
+                border: `1px solid ${tokens.primary}33`,
+                borderRadius: '6px',
+                px: 1.5,
+                py: 0.75,
+              }}
+            >
+              <Typography
+                sx={{
+                  fontSize: '0.6875rem',
+                  fontWeight: 800,
+                  letterSpacing: '0.08em',
+                  textTransform: 'uppercase',
+                  color: tokens.primary,
+                }}
+              >
+                Tu predicción
+              </Typography>
+              <Typography
+                sx={{
+                  color: tokens.onSurface,
+                  fontWeight: 900,
+                  fontSize: '0.875rem',
+                  ml: 0.5,
+                }}
+              >
+                {match.prediction.home} - {match.prediction.away}
+              </Typography>
+            </Box>
+          ) : null}
+
+          {/* 2. Badge de Resultado: [X INCORRECTO] */}
+          <Box
+            sx={{
+              display: 'flex',
+              alignItems: 'center',
+              gap: 0.75,
+              bgcolor: `${resultColor}12`,
+              color: resultColor,
+              border: `1px solid ${resultColor}40`,
+              borderRadius: '6px',
+              px: 1.5,
+              py: 0.75,
+              fontSize: '0.6875rem',
+              fontWeight: 800,
+              textTransform: 'uppercase',
+              letterSpacing: '0.08em',
+            }}
+          >
+            <span>{resultIcon}</span>
+            {resultLabel}
+          </Box>
+
+          {/* 3. Badge de Puntaje Ganado: [+2 PTS] */}
+          {match.prediction ? (
+            <Box
+              sx={{
+                display: 'flex',
+                alignItems: 'center',
+                gap: 0.75,
+                bgcolor: `${totalPoints > 0 ? tokens.primary : tokens.onSurfaceVariant}12`,
+                border: `1px solid ${totalPoints > 0 ? tokens.primary : tokens.onSurfaceVariant}33`,
+                borderRadius: '6px',
+                px: 1.5,
+                py: 0.75,
+                fontSize: '0.6875rem',
+                fontWeight: 800,
+                textTransform: 'uppercase',
+                letterSpacing: '0.08em',
+                color: totalPoints > 0 ? tokens.primary : tokens.onSurfaceVariant,
+              }}
+            >
+              {totalPoints > 0 ? `+${totalPoints}` : '0'} {totalPoints === 1 ? 'pt' : 'pts'}
+            </Box>
+          ) : (
+            <Box
+              sx={{
+                display: 'flex',
+                alignItems: 'center',
+                gap: 0.75,
+                bgcolor: `${tokens.onSurfaceVariant}12`,
+                border: `1px solid ${tokens.onSurfaceVariant}33`,
+                borderRadius: '6px',
+                px: 1.5,
+                py: 0.75,
+                fontSize: '0.6875rem',
+                fontWeight: 800,
+                textTransform: 'uppercase',
+                letterSpacing: '0.08em',
+                color: tokens.onSurfaceVariant,
+              }}
+            >
+              0 pts
+            </Box>
+          )}
+        </Box>
+      </Box>
+    </Box>
+  );
+};
+
+export default FinishedMatchCard;

--- a/src/features/matches/components/molecules/MatchCard.tsx
+++ b/src/features/matches/components/molecules/MatchCard.tsx
@@ -11,6 +11,13 @@ import TeamBlock from '../atoms/TeamBlock';
 import ScoreOrVs from '../atoms/ScoreOrVs';
 import MatchStatusChip from '../atoms/MatchStatusChip';
 import AppButton from '@shared/components/atoms/AppButton';
+import { useTranslations } from 'next-intl';
+import {
+  evaluatePrediction,
+  getPredictionResultColor,
+  getPredictionResultIcon,
+  calculatePredictionPoints,
+} from '../../utils/predictionEvaluator';
 
 const STATUS_META: Record<MatchStatus, { color: string; Icon: typeof AccessTimeIcon }> = {
   upcoming: { color: tokens.tertiary, Icon: AccessTimeIcon },
@@ -45,6 +52,7 @@ const MatchCard = ({
   onAddPrediction,
   onEditPrediction,
 }: Props) => {
+  const tResults = useTranslations('results');
   const meta = STATUS_META[match.status];
   const StatusIcon = meta.Icon;
   const showScore = match.status === 'live' || match.status === 'finished';
@@ -127,7 +135,147 @@ const MatchCard = ({
           justifyContent: 'space-between',
         }}
       >
-        {hasPrediction ? (
+        {match.status === 'finished' ? (
+          (() => {
+            const predictionResult = match.score
+              ? evaluatePrediction(match.score, match.prediction)
+              : 'no-prediction';
+            const resultColor = getPredictionResultColor(predictionResult);
+            const resultIcon = getPredictionResultIcon(predictionResult);
+            const resultLabel = (() => {
+              switch (predictionResult) {
+                case 'exact':
+                  return tResults('exact') || 'Acierto exacto';
+                case 'partial':
+                  return tResults('partial') || 'Acierto parcial';
+                case 'wrong':
+                  return tResults('wrong') || 'Incorrecto';
+                case 'no-prediction':
+                default:
+                  return tResults('noPrediction') || 'Sin predicción';
+              }
+            })();
+
+            const totalPoints =
+              match.score && match.prediction
+                ? calculatePredictionPoints(match.score, match.prediction).totalPoints
+                : 0;
+
+            return (
+              <Box
+                sx={{
+                  display: 'flex',
+                  alignItems: 'center',
+                  flexWrap: 'wrap',
+                  gap: 1.25,
+                }}
+              >
+                {/* 1. Badge de Predicción: [TU PREDICCIÓN 0 - 0] */}
+                {match.prediction ? (
+                  <Box
+                    sx={{
+                      display: 'flex',
+                      alignItems: 'center',
+                      gap: 1,
+                      bgcolor: `${tokens.primary}0F`,
+                      border: `1px solid ${tokens.primary}33`,
+                      borderRadius: '6px',
+                      px: 1.5,
+                      py: 0.75,
+                    }}
+                  >
+                    <Typography
+                      sx={{
+                        fontSize: '0.6875rem',
+                        fontWeight: 800,
+                        letterSpacing: '0.08em',
+                        textTransform: 'uppercase',
+                        color: tokens.primary,
+                      }}
+                    >
+                      Tu predicción
+                    </Typography>
+                    <Typography
+                      sx={{
+                        color: tokens.onSurface,
+                        fontWeight: 900,
+                        fontSize: '0.875rem',
+                        ml: 0.5,
+                      }}
+                    >
+                      {match.prediction.home} - {match.prediction.away}
+                    </Typography>
+                  </Box>
+                ) : null}
+
+                {/* 2. Badge de Resultado: [X INCORRECTO] */}
+                <Box
+                  sx={{
+                    display: 'flex',
+                    alignItems: 'center',
+                    gap: 0.75,
+                    bgcolor: `${resultColor}12`,
+                    color: resultColor,
+                    border: `1px solid ${resultColor}40`,
+                    borderRadius: '6px',
+                    px: 1.5,
+                    py: 0.75,
+                    fontSize: '0.6875rem',
+                    fontWeight: 800,
+                    textTransform: 'uppercase',
+                    letterSpacing: '0.08em',
+                  }}
+                >
+                  <span>{resultIcon}</span>
+                  {resultLabel}
+                </Box>
+
+                {/* 3. Badge de Puntaje Ganado: [+2 PTS] */}
+                {match.prediction ? (
+                  <Box
+                    sx={{
+                      display: 'flex',
+                      alignItems: 'center',
+                      gap: 0.75,
+                      bgcolor: `${totalPoints > 0 ? tokens.primary : tokens.onSurfaceVariant}12`,
+                      border: `1px solid ${totalPoints > 0 ? tokens.primary : tokens.onSurfaceVariant}33`,
+                      borderRadius: '6px',
+                      px: 1.5,
+                      py: 0.75,
+                      fontSize: '0.6875rem',
+                      fontWeight: 800,
+                      textTransform: 'uppercase',
+                      letterSpacing: '0.08em',
+                      color: totalPoints > 0 ? tokens.primary : tokens.onSurfaceVariant,
+                    }}
+                  >
+                    {totalPoints > 0 ? `+${totalPoints}` : '0'} {totalPoints === 1 ? 'pt' : 'pts'}
+                  </Box>
+                ) : (
+                  <Box
+                    sx={{
+                      display: 'flex',
+                      alignItems: 'center',
+                      gap: 0.75,
+                      bgcolor: `${tokens.onSurfaceVariant}12`,
+                      border: `1px solid ${tokens.onSurfaceVariant}33`,
+                      borderRadius: '6px',
+                      px: 1.5,
+                      py: 0.75,
+                      fontSize: '0.6875rem',
+                      fontWeight: 800,
+                      textTransform: 'uppercase',
+                      letterSpacing: '0.08em',
+                      color: tokens.onSurfaceVariant,
+                    }}
+                  >
+                    0 pts
+                  </Box>
+                )}
+              </Box>
+            );
+          })()
+        ) : hasPrediction ? (
           <Box
             sx={{
               display: 'flex',
@@ -168,13 +316,15 @@ const MatchCard = ({
             justifyContent: { xs: 'stretch', sm: 'flex-end' },
           }}
         >
-          <AppButton
-            variant="primary"
-            onClick={() => (hasPrediction ? onEditPrediction?.(match) : onAddPrediction?.(match))}
-            sx={{ flex: { xs: 1, sm: 'unset' } }}
-          >
-            {hasPrediction ? editPredictionLabel : addPredictionLabel}
-          </AppButton>
+          {match.status === 'upcoming' && (
+            <AppButton
+              variant="primary"
+              onClick={() => (hasPrediction ? onEditPrediction?.(match) : onAddPrediction?.(match))}
+              sx={{ flex: { xs: 1, sm: 'unset' } }}
+            >
+              {hasPrediction ? editPredictionLabel : addPredictionLabel}
+            </AppButton>
+          )}
         </Box>
       </Box>
     </Box>

--- a/src/features/matches/hooks/useMatchesList.ts
+++ b/src/features/matches/hooks/useMatchesList.ts
@@ -4,6 +4,7 @@ import { useEffect, useMemo, useState } from 'react';
 import type { Match } from '../types';
 import type { MatchesFilterKey } from '../components/molecules/MatchesFilters';
 import { matchesService } from '../services/matchesService';
+import { useAuthStore } from '@features/auth/store/useAuthStore';
 import {
   statusFromFilter,
   worldCupWeekToFromToIso,
@@ -23,9 +24,12 @@ type UseMatchesListState = {
   total: number;
 };
 
-export const useMatchesList = (initialPageSize = 10): UseMatchesListState => {
+export const useMatchesList = (
+  initialPageSize = 10,
+  initialFilter: MatchesFilterKey = 'filterAll',
+): UseMatchesListState => {
   const [query, setQuery] = useState<MatchesQuery>({
-    statusFilter: 'filterAll',
+    statusFilter: initialFilter,
     team: '',
     week: '',
     page: 1,
@@ -35,6 +39,8 @@ export const useMatchesList = (initialPageSize = 10): UseMatchesListState => {
   const [items, setItems] = useState<Match[]>([]);
   const [total, setTotal] = useState(0);
   const [loading, setLoading] = useState(true);
+
+  const userId = useAuthStore((s) => s.session?.user.id);
 
   const params = useMemo(() => {
     const status = statusFromFilter(query.statusFilter);
@@ -67,7 +73,7 @@ export const useMatchesList = (initialPageSize = 10): UseMatchesListState => {
     return () => {
       mounted = false;
     };
-  }, [params]);
+  }, [params, userId]);
 
   const setStatusFilter = (filter: MatchesFilterKey) =>
     setQuery((q) => ({ ...q, statusFilter: filter, page: 1 }));
@@ -78,7 +84,7 @@ export const useMatchesList = (initialPageSize = 10): UseMatchesListState => {
     setQuery((q) => ({ ...q, pageSize: Math.max(1, pageSize), page: 1 }));
 
   const resetFilters = () =>
-    setQuery((q) => ({ ...q, statusFilter: 'filterAll', team: '', week: '', page: 1 }));
+    setQuery((q) => ({ ...q, statusFilter: initialFilter, team: '', week: '', page: 1 }));
 
   return {
     query,

--- a/src/features/matches/services/gateways/MockMatchesGateway.ts
+++ b/src/features/matches/services/gateways/MockMatchesGateway.ts
@@ -1,10 +1,36 @@
 import type { Match } from '../../types';
 import type { ListMatchesParams, MatchesGateway, PaginatedResult } from '../MatchesGateway';
 import { MOCK_MATCHES } from '../../data/mockMatches';
+import { useAuthStore } from '@features/auth/store/useAuthStore';
+
+const USER_PREDICTIONS: Record<
+  string,
+  Record<string, { home: number; away: number } | undefined>
+> = {
+  'admin-user': {
+    'm-fin-03': { home: 0, away: 0 },
+    'm-fin-02': { home: 2, away: 1 },
+    'm-fin-01': { home: 1, away: 2 },
+  },
+  'mock-user-1': {
+    'm-fin-03': { home: 0, away: 1 },
+    'm-fin-02': undefined,
+    'm-fin-01': { home: 0, away: 3 },
+  },
+  'mock-user-2': {
+    'm-fin-03': { home: 1, away: 3 },
+    'm-fin-02': { home: 2, away: 2 },
+    'm-fin-01': { home: 0, away: 0 },
+  },
+  'mock-user-3': {
+    'm-fin-03': { home: 2, away: 0 },
+    'm-fin-02': { home: 1, away: 1 },
+    'm-fin-01': { home: 3, away: 1 },
+  },
+};
 
 const applyMockFilters = (matches: Match[], params?: ListMatchesParams) => {
   if (!params) return matches;
-  // En el mock por ahora sólo filtramos por rango de fecha si viene.
   const fromMs = params.from ? new Date(params.from).getTime() : undefined;
   const toMs = params.to ? new Date(params.to).getTime() : undefined;
   const q = params.team?.trim().toLowerCase();
@@ -25,7 +51,21 @@ const applyMockFilters = (matches: Match[], params?: ListMatchesParams) => {
 
 export class MockMatchesGateway implements MatchesGateway {
   async listMatches(params?: ListMatchesParams): Promise<PaginatedResult<Match>> {
-    const filtered = applyMockFilters(MOCK_MATCHES, params);
+    // Obtener usuario actual del Zustand store
+    const userId = useAuthStore.getState().session?.user.id;
+
+    // Mapear partidos dinámicamente según las predicciones del usuario actual
+    const mappedMatches = MOCK_MATCHES.map((match) => {
+      if (userId && USER_PREDICTIONS[userId] && match.id in USER_PREDICTIONS[userId]) {
+        return {
+          ...match,
+          prediction: USER_PREDICTIONS[userId][match.id],
+        };
+      }
+      return match;
+    });
+
+    const filtered = applyMockFilters(mappedMatches, params);
 
     const pageSize = Math.max(1, params?.pageSize ?? 10);
     const page = Math.max(1, params?.page ?? 1);

--- a/src/features/matches/utils/predictionEvaluator.ts
+++ b/src/features/matches/utils/predictionEvaluator.ts
@@ -1,0 +1,146 @@
+import { MatchScore, MatchPrediction } from '../types';
+
+export type PredictionResult = 'exact' | 'partial' | 'wrong' | 'no-prediction';
+
+/**
+ * Evalúa el resultado de una predicción comparándola con el marcador real del partido.
+ *
+ * @param actualScore - Marcador real del partido
+ * @param prediction - Predicción del usuario
+ * @returns 'exact' si acertó el marcador exacto, 'partial' si acertó el ganador,
+ *          'wrong' si se equivocó, 'no-prediction' si no hizo predicción
+ */
+export const evaluatePrediction = (
+  actualScore: MatchScore,
+  prediction?: MatchPrediction,
+): PredictionResult => {
+  if (!prediction) return 'no-prediction';
+
+  const { home: actualHome, away: actualAway } = actualScore;
+  const { home: predHome, away: predAway } = prediction;
+
+  // Acierto exacto
+  if (actualHome === predHome && actualAway === predAway) {
+    return 'exact';
+  }
+
+  // Acierto parcial: acertó quién gana o empate
+  const actualDiff = actualHome - actualAway;
+  const predDiff = predHome - predAway;
+
+  // Mismo signo = mismo resultado (ganó local, empate, o ganó visitante)
+  if (
+    (actualDiff > 0 && predDiff > 0) ||
+    (actualDiff < 0 && predDiff < 0) ||
+    (actualDiff === 0 && predDiff === 0)
+  ) {
+    return 'partial';
+  }
+
+  return 'wrong';
+};
+
+/**
+ * Obtiene un color basado en el resultado de la predicción para visualización en UI.
+ */
+export const getPredictionResultColor = (result: PredictionResult): string => {
+  switch (result) {
+    case 'exact':
+      return '#00C853'; // Verde - tokens.success
+    case 'partial':
+      return '#ff8a00'; // Naranja - tokens.secondary
+    case 'wrong':
+      return '#ff6e84'; // Rojo - tokens.error
+    case 'no-prediction':
+    default:
+      return '#acaab5'; // Gris - tokens.onSurfaceVariant
+  }
+};
+
+/**
+ * Obtiene un icono/emoji basado en el resultado de la predicción.
+ */
+export const getPredictionResultIcon = (result: PredictionResult): string => {
+  switch (result) {
+    case 'exact':
+      return '👑';
+    case 'partial':
+      return '⚽';
+    case 'wrong':
+      return '❌';
+    case 'no-prediction':
+    default:
+      return '—';
+  }
+};
+
+export type PointModifier = {
+  key: string;
+  points: number;
+};
+
+export type PredictionPointsDetails = {
+  totalPoints: number;
+  modifiers: PointModifier[];
+};
+
+/**
+ * Calcula el puntaje obtenido por una predicción en base a las reglas de Skorify.
+ */
+export const calculatePredictionPoints = (
+  actualScore: MatchScore,
+  prediction?: MatchPrediction,
+): PredictionPointsDetails => {
+  if (!prediction) {
+    return { totalPoints: 0, modifiers: [] };
+  }
+
+  const { home: actualHome, away: actualAway } = actualScore;
+  const { home: predHome, away: predAway } = prediction;
+
+  const modifiers: PointModifier[] = [];
+  let totalPoints = 0;
+
+  // 1. Ganador (+2 pts)
+  const actualDiff = actualHome - actualAway;
+  const predDiff = predHome - predAway;
+  const isWinnerCorrect =
+    (actualDiff > 0 && predDiff > 0) ||
+    (actualDiff < 0 && predDiff < 0) ||
+    (actualDiff === 0 && predDiff === 0);
+
+  if (isWinnerCorrect) {
+    modifiers.push({ key: 'winner', points: 2 });
+    totalPoints += 2;
+  }
+
+  // 2. Cada aciertos (+1 pt por equipo con goles coincidentes)
+  if (actualHome === predHome) {
+    modifiers.push({ key: 'homeGoals', points: 1 });
+    totalPoints += 1;
+  }
+  if (actualAway === predAway) {
+    modifiers.push({ key: 'awayGoals', points: 1 });
+    totalPoints += 1;
+  }
+
+  // 3. Marcador abultado (+1 pt) - Goleada: total goles real > 4
+  const totalActualGoals = actualHome + actualAway;
+  if (totalActualGoals > 4) {
+    modifiers.push({ key: 'lopsided', points: 1 });
+    totalPoints += 1;
+  }
+
+  // 4. Marcador invertido (+1 pt) - Si falló el ganador pero el marcador es al revés (ej: real 2-1, pred 1-2)
+  if (
+    !isWinnerCorrect &&
+    actualHome === predAway &&
+    actualAway === predHome &&
+    actualHome !== actualAway
+  ) {
+    modifiers.push({ key: 'reverse', points: 1 });
+    totalPoints += 1;
+  }
+
+  return { totalPoints, modifiers };
+};

--- a/src/i18n/messages/en.json
+++ b/src/i18n/messages/en.json
@@ -30,11 +30,32 @@
     "matches": "Matches",
     "matchesList": "Matches",
     "loadResults": "Load results",
+    "results": "Results",
     "admin": "Admin",
     "users": "Users",
     "tournaments": "Tournaments",
     "groups": "Groups",
     "profile": "Profile"
+  },
+  "results": {
+    "title": "Results",
+    "subtitle": "History of finished matches and predictions",
+    "loading": "Loading results...",
+    "noMatches": "No finished matches found.",
+    "exact": "Exact Match",
+    "partial": "Partial Match",
+    "wrong": "Incorrect",
+    "noPrediction": "No prediction",
+    "earnedPoints": "Earned points: {points}",
+    "exactHit": "Exact match (+2 pts)",
+    "partialHit": "Partial match (+1 pt)",
+    "noPoints": "No points (0 pts)",
+    "pointsSummaryTitle": "Points breakdown",
+    "modifierExact": "Exact match",
+    "modifierPartial": "Partial match",
+    "modifierWrong": "No match",
+    "modifierGoalDiff": "Goal difference",
+    "modifierGoalCount": "Goals scored"
   },
   "profile": {
     "title": "Your profile",
@@ -264,6 +285,7 @@
       "fallbackAway": "Away"
     }
   },
+
   "tournaments": {
     "title": "Tournaments",
     "active": "Active",
@@ -340,6 +362,9 @@
     "predictionsCardTitle": "Upcoming matches",
     "predictionsCardSubtitle": "Make your predictions and earn points",
     "predictionsCardCta": "Go to predictions",
+    "finishedMatchesTitle": "Results",
+    "finishedMatchesSubtitle": "See finished matches",
+    "backToGroup": "Back to group",
     "membersTitle": "Members",
     "shareButton": "Share",
     "shareTitle": "Share group",

--- a/src/i18n/messages/es.json
+++ b/src/i18n/messages/es.json
@@ -35,11 +35,32 @@
     "matches": "Partidos",
     "matchesList": "Partidos",
     "loadResults": "Cargar resultados",
+    "results": "Resultados",
     "admin": "Administrador",
     "users": "Usuarios",
     "tournaments": "Torneos",
     "groups": "Grupos",
     "profile": "Perfil"
+  },
+  "results": {
+    "title": "Resultados",
+    "subtitle": "Historial de partidos finalizados y predicciones",
+    "loading": "Cargando resultados...",
+    "noMatches": "No se encontraron partidos finalizados.",
+    "exact": "Acierto exacto",
+    "partial": "Acierto parcial",
+    "wrong": "Incorrecto",
+    "noPrediction": "Sin predicción",
+    "earnedPoints": "Puntos ganados: {points}",
+    "exactHit": "Acierto exacto (+2 pts)",
+    "partialHit": "Acierto parcial (+1 pt)",
+    "noPoints": "Sin puntos (0 pts)",
+    "pointsSummaryTitle": "Detalle de puntos",
+    "modifierExact": "Acierto exacto",
+    "modifierPartial": "Acierto parcial",
+    "modifierWrong": "Sin coincidencia",
+    "modifierGoalDiff": "Diferencia de goles",
+    "modifierGoalCount": "Goles anotados"
   },
   "profile": {
     "title": "Tu perfil",
@@ -269,6 +290,7 @@
       "fallbackAway": "Visitante"
     }
   },
+
   "tournaments": {
     "title": "Torneos",
     "active": "Activos",
@@ -345,6 +367,9 @@
     "predictionsCardTitle": "Próximos partidos",
     "predictionsCardSubtitle": "Haz tus predicciones y suma puntos",
     "predictionsCardCta": "Ir a predicciones",
+    "finishedMatchesTitle": "Resultados",
+    "finishedMatchesSubtitle": "Ver partidos finalizados",
+    "backToGroup": "Volver al grupo",
     "membersTitle": "Miembros",
     "shareButton": "Compartir",
     "shareTitle": "Compartir grupo",

--- a/src/i18n/request.ts
+++ b/src/i18n/request.ts
@@ -7,5 +7,12 @@ export default getRequestConfig(async () => {
   return {
     locale,
     messages: (await import(`./messages/${locale}.json`)).default,
+    onError(_error) {
+      // Suppress full-screen error overlays for missing translations
+    },
+    getMessageFallback({ namespace: _namespace, key }) {
+      // Gracefully fall back to the last segment of the key
+      return key.split('.').pop() || key;
+    },
   };
 });

--- a/src/shared/layouts/DashboardBottomNav.tsx
+++ b/src/shared/layouts/DashboardBottomNav.tsx
@@ -21,6 +21,7 @@ import GroupIcon from '@mui/icons-material/Group';
 import HomeIcon from '@mui/icons-material/Home';
 import SportsSoccerIcon from '@mui/icons-material/SportsSoccer';
 import UploadFileIcon from '@mui/icons-material/UploadFile';
+import LeaderboardIcon from '@mui/icons-material/Leaderboard';
 import { type SvgIconProps } from '@mui/material/SvgIcon';
 import Link from 'next/link';
 import { tokens } from '@lib/theme/theme';
@@ -39,6 +40,7 @@ const BOTTOM_NAV_ITEMS: ReadonlyArray<BottomNavItem> = [
     children: [
       { key: 'matchesList', href: '/matches', Icon: CalendarMonthIcon },
       { key: 'predictions', href: '/predictions', Icon: SportsSoccerIcon },
+      { key: 'results', href: '/results', Icon: LeaderboardIcon },
       { key: 'loadResults', href: '/matches/load-results', Icon: UploadFileIcon },
     ],
   },

--- a/src/shared/layouts/drawerItems.ts
+++ b/src/shared/layouts/drawerItems.ts
@@ -4,6 +4,7 @@ import CalendarMonthIcon from '@mui/icons-material/CalendarMonth';
 import EmojiEventsIcon from '@mui/icons-material/EmojiEvents';
 import GroupIcon from '@mui/icons-material/Group';
 import HomeIcon from '@mui/icons-material/Home';
+import LeaderboardIcon from '@mui/icons-material/Leaderboard';
 import SportsSoccerIcon from '@mui/icons-material/SportsSoccer';
 import UploadFileIcon from '@mui/icons-material/UploadFile';
 import WorkspacePremiumIcon from '@mui/icons-material/WorkspacePremium';
@@ -23,6 +24,7 @@ const baseItems: ReadonlyArray<DrawerItem> = [
     children: [
       { key: 'matchesList', href: '/matches', Icon: CalendarMonthIcon },
       { key: 'predictions', href: '/predictions', Icon: SportsSoccerIcon },
+      { key: 'results', href: '/results', Icon: LeaderboardIcon },
     ],
   },
   { key: 'tournaments', href: '/tournaments', Icon: EmojiEventsIcon },

--- a/yarn.lock
+++ b/yarn.lock
@@ -16,7 +16,7 @@
   resolved "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.0.tgz"
   integrity sha512-T1NCJqT/j9+cn8fvkt7jtwbLBfLC/1y1c7NtCeXFRgzGTsafi68MRv8yzkYSapBnFA6L3U2VSc02ciDzoAJhJg==
 
-"@babel/core@^7.0.0", "@babel/core@^7.24.4":
+"@babel/core@^7.24.4":
   version "7.29.0"
   resolved "https://registry.npmjs.org/@babel/core/-/core-7.29.0.tgz"
   integrity sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==
@@ -146,6 +146,28 @@
     "@babel/helper-string-parser" "^7.27.1"
     "@babel/helper-validator-identifier" "^7.28.5"
 
+"@emnapi/core@^1.4.3":
+  version "1.10.0"
+  resolved "https://registry.yarnpkg.com/@emnapi/core/-/core-1.10.0.tgz#380ccc8f2412ea22d1d972df7f8ee23a3b9c7467"
+  integrity sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==
+  dependencies:
+    "@emnapi/wasi-threads" "1.2.1"
+    tslib "^2.4.0"
+
+"@emnapi/runtime@^1.4.3", "@emnapi/runtime@^1.7.0":
+  version "1.10.0"
+  resolved "https://registry.yarnpkg.com/@emnapi/runtime/-/runtime-1.10.0.tgz#4b260c0d3534204e98c6110b8db1a987d26ec87c"
+  integrity sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==
+  dependencies:
+    tslib "^2.4.0"
+
+"@emnapi/wasi-threads@1.2.1":
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz#28fed21a1ba1ce797c44a070abc94d42f3ae8548"
+  integrity sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==
+  dependencies:
+    tslib "^2.4.0"
+
 "@emotion/babel-plugin@^11.13.5":
   version "11.13.5"
   resolved "https://registry.npmjs.org/@emotion/babel-plugin/-/babel-plugin-11.13.5.tgz"
@@ -191,7 +213,7 @@
   resolved "https://registry.npmjs.org/@emotion/memoize/-/memoize-0.9.0.tgz"
   integrity sha512-30FAj7/EoJ5mwVPOWhAyCX+FPfMDrVecJAM+Iw9NRoSl4BBAQeqj4cApHHUXOVvIPgLVDsCFoz/hGD+5QQD1GQ==
 
-"@emotion/react@^11.0.0-rc.0", "@emotion/react@^11.14.0", "@emotion/react@^11.4.1", "@emotion/react@^11.5.0", "@emotion/react@^11.9.0":
+"@emotion/react@^11.14.0":
   version "11.14.0"
   resolved "https://registry.npmjs.org/@emotion/react/-/react-11.14.0.tgz"
   integrity sha512-O000MLDBDdk/EohJPFUqvnp4qnHeYkVP5B0xEG0D/L7cOKP9kefu2DXn8dj74cQfsEzUqh+sr1RzFqiL1o+PpA==
@@ -221,7 +243,7 @@
   resolved "https://registry.npmjs.org/@emotion/sheet/-/sheet-1.4.0.tgz"
   integrity sha512-fTBW9/8r2w3dXWYM4HCB1Rdp8NLibOw2+XELH5m5+AkWiL/KqYX6dc0kKYlaYyKjrQ6ds33MCdMPEwgs2z1rqg==
 
-"@emotion/styled@^11.14.1", "@emotion/styled@^11.3.0", "@emotion/styled@^11.8.1":
+"@emotion/styled@^11.14.1":
   version "11.14.1"
   resolved "https://registry.npmjs.org/@emotion/styled/-/styled-11.14.1.tgz"
   integrity sha512-qEEJt42DuToa3gurlH4Qqc1kVpNq8wO8cJtDzU46TjlzWjDlsVyevtYCRijVq3SrHsROS+gVQ8Fnea108GnKzw==
@@ -321,12 +343,12 @@
     "@eslint/core" "^0.17.0"
     levn "^0.4.1"
 
-"@formatjs/fast-memoize@^3.1.0", "@formatjs/fast-memoize@3.1.2":
+"@formatjs/fast-memoize@3.1.2", "@formatjs/fast-memoize@^3.1.0":
   version "3.1.2"
   resolved "https://registry.npmjs.org/@formatjs/fast-memoize/-/fast-memoize-3.1.2.tgz"
   integrity sha512-vPnriihkfK0lzoQGaXq+qXH23VsYyansRTkTgo2aTG0k1NjLFyZimFVdfj4C9JkSE5dm7CEngcQ5TTc1yAyBfQ==
 
-"@formatjs/icu-messageformat-parser@^3.4.0", "@formatjs/icu-messageformat-parser@3.5.4":
+"@formatjs/icu-messageformat-parser@3.5.4", "@formatjs/icu-messageformat-parser@^3.4.0":
   version "3.5.4"
   resolved "https://registry.npmjs.org/@formatjs/icu-messageformat-parser/-/icu-messageformat-parser-3.5.4.tgz"
   integrity sha512-JVY39ROgLt+pIYngo6piyj4OVfZmXs/2FkC4wLS+ql1Eig/sGJKB7YwDO/5bkJFkfwaFAeIpgEiJc8hiYxNalw==
@@ -388,6 +410,143 @@
   resolved "https://registry.npmjs.org/@img/colour/-/colour-1.1.0.tgz"
   integrity sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ==
 
+"@img/sharp-darwin-arm64@0.34.5":
+  version "0.34.5"
+  resolved "https://registry.yarnpkg.com/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.34.5.tgz#6e0732dcade126b6670af7aa17060b926835ea86"
+  integrity sha512-imtQ3WMJXbMY4fxb/Ndp6HBTNVtWCUI0WdobyheGf5+ad6xX8VIDO8u2xE4qc/fr08CKG/7dDseFtn6M6g/r3w==
+  optionalDependencies:
+    "@img/sharp-libvips-darwin-arm64" "1.2.4"
+
+"@img/sharp-darwin-x64@0.34.5":
+  version "0.34.5"
+  resolved "https://registry.yarnpkg.com/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.34.5.tgz#19bc1dd6eba6d5a96283498b9c9f401180ee9c7b"
+  integrity sha512-YNEFAF/4KQ/PeW0N+r+aVVsoIY0/qxxikF2SWdp+NRkmMB7y9LBZAVqQ4yhGCm/H3H270OSykqmQMKLBhBJDEw==
+  optionalDependencies:
+    "@img/sharp-libvips-darwin-x64" "1.2.4"
+
+"@img/sharp-libvips-darwin-arm64@1.2.4":
+  version "1.2.4"
+  resolved "https://registry.yarnpkg.com/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.2.4.tgz#2894c0cb87d42276c3889942e8e2db517a492c43"
+  integrity sha512-zqjjo7RatFfFoP0MkQ51jfuFZBnVE2pRiaydKJ1G/rHZvnsrHAOcQALIi9sA5co5xenQdTugCvtb1cuf78Vf4g==
+
+"@img/sharp-libvips-darwin-x64@1.2.4":
+  version "1.2.4"
+  resolved "https://registry.yarnpkg.com/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.2.4.tgz#e63681f4539a94af9cd17246ed8881734386f8cc"
+  integrity sha512-1IOd5xfVhlGwX+zXv2N93k0yMONvUlANylbJw1eTah8K/Jtpi15KC+WSiaX/nBmbm2HxRM1gZ0nSdjSsrZbGKg==
+
+"@img/sharp-libvips-linux-arm64@1.2.4":
+  version "1.2.4"
+  resolved "https://registry.yarnpkg.com/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.2.4.tgz#b1b288b36864b3bce545ad91fa6dadcf1a4ad318"
+  integrity sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==
+
+"@img/sharp-libvips-linux-arm@1.2.4":
+  version "1.2.4"
+  resolved "https://registry.yarnpkg.com/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.2.4.tgz#b9260dd1ebe6f9e3bdbcbdcac9d2ac125f35852d"
+  integrity sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==
+
+"@img/sharp-libvips-linux-ppc64@1.2.4":
+  version "1.2.4"
+  resolved "https://registry.yarnpkg.com/@img/sharp-libvips-linux-ppc64/-/sharp-libvips-linux-ppc64-1.2.4.tgz#4b83ecf2a829057222b38848c7b022e7b4d07aa7"
+  integrity sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==
+
+"@img/sharp-libvips-linux-riscv64@1.2.4":
+  version "1.2.4"
+  resolved "https://registry.yarnpkg.com/@img/sharp-libvips-linux-riscv64/-/sharp-libvips-linux-riscv64-1.2.4.tgz#880b4678009e5a2080af192332b00b0aaf8a48de"
+  integrity sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==
+
+"@img/sharp-libvips-linux-s390x@1.2.4":
+  version "1.2.4"
+  resolved "https://registry.yarnpkg.com/@img/sharp-libvips-linux-s390x/-/sharp-libvips-linux-s390x-1.2.4.tgz#74f343c8e10fad821b38f75ced30488939dc59ec"
+  integrity sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==
+
+"@img/sharp-libvips-linux-x64@1.2.4":
+  version "1.2.4"
+  resolved "https://registry.yarnpkg.com/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.2.4.tgz#df4183e8bd8410f7d61b66859a35edeab0a531ce"
+  integrity sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==
+
+"@img/sharp-libvips-linuxmusl-arm64@1.2.4":
+  version "1.2.4"
+  resolved "https://registry.yarnpkg.com/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.2.4.tgz#c8d6b48211df67137541007ee8d1b7b1f8ca8e06"
+  integrity sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==
+
+"@img/sharp-libvips-linuxmusl-x64@1.2.4":
+  version "1.2.4"
+  resolved "https://registry.yarnpkg.com/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.2.4.tgz#be11c75bee5b080cbee31a153a8779448f919f75"
+  integrity sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==
+
+"@img/sharp-linux-arm64@0.34.5":
+  version "0.34.5"
+  resolved "https://registry.yarnpkg.com/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.34.5.tgz#7aa7764ef9c001f15e610546d42fce56911790cc"
+  integrity sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==
+  optionalDependencies:
+    "@img/sharp-libvips-linux-arm64" "1.2.4"
+
+"@img/sharp-linux-arm@0.34.5":
+  version "0.34.5"
+  resolved "https://registry.yarnpkg.com/@img/sharp-linux-arm/-/sharp-linux-arm-0.34.5.tgz#5fb0c3695dd12522d39c3ff7a6bc816461780a0d"
+  integrity sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==
+  optionalDependencies:
+    "@img/sharp-libvips-linux-arm" "1.2.4"
+
+"@img/sharp-linux-ppc64@0.34.5":
+  version "0.34.5"
+  resolved "https://registry.yarnpkg.com/@img/sharp-linux-ppc64/-/sharp-linux-ppc64-0.34.5.tgz#9c213a81520a20caf66978f3d4c07456ff2e0813"
+  integrity sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==
+  optionalDependencies:
+    "@img/sharp-libvips-linux-ppc64" "1.2.4"
+
+"@img/sharp-linux-riscv64@0.34.5":
+  version "0.34.5"
+  resolved "https://registry.yarnpkg.com/@img/sharp-linux-riscv64/-/sharp-linux-riscv64-0.34.5.tgz#cdd28182774eadbe04f62675a16aabbccb833f60"
+  integrity sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==
+  optionalDependencies:
+    "@img/sharp-libvips-linux-riscv64" "1.2.4"
+
+"@img/sharp-linux-s390x@0.34.5":
+  version "0.34.5"
+  resolved "https://registry.yarnpkg.com/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.34.5.tgz#93eac601b9f329bb27917e0e19098c722d630df7"
+  integrity sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==
+  optionalDependencies:
+    "@img/sharp-libvips-linux-s390x" "1.2.4"
+
+"@img/sharp-linux-x64@0.34.5":
+  version "0.34.5"
+  resolved "https://registry.yarnpkg.com/@img/sharp-linux-x64/-/sharp-linux-x64-0.34.5.tgz#55abc7cd754ffca5002b6c2b719abdfc846819a8"
+  integrity sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==
+  optionalDependencies:
+    "@img/sharp-libvips-linux-x64" "1.2.4"
+
+"@img/sharp-linuxmusl-arm64@0.34.5":
+  version "0.34.5"
+  resolved "https://registry.yarnpkg.com/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.34.5.tgz#d6515ee971bb62f73001a4829b9d865a11b77086"
+  integrity sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==
+  optionalDependencies:
+    "@img/sharp-libvips-linuxmusl-arm64" "1.2.4"
+
+"@img/sharp-linuxmusl-x64@0.34.5":
+  version "0.34.5"
+  resolved "https://registry.yarnpkg.com/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.34.5.tgz#d97978aec7c5212f999714f2f5b736457e12ee9f"
+  integrity sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==
+  optionalDependencies:
+    "@img/sharp-libvips-linuxmusl-x64" "1.2.4"
+
+"@img/sharp-wasm32@0.34.5":
+  version "0.34.5"
+  resolved "https://registry.yarnpkg.com/@img/sharp-wasm32/-/sharp-wasm32-0.34.5.tgz#2f15803aa626f8c59dd7c9d0bbc766f1ab52cfa0"
+  integrity sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==
+  dependencies:
+    "@emnapi/runtime" "^1.7.0"
+
+"@img/sharp-win32-arm64@0.34.5":
+  version "0.34.5"
+  resolved "https://registry.yarnpkg.com/@img/sharp-win32-arm64/-/sharp-win32-arm64-0.34.5.tgz#3706e9e3ac35fddfc1c87f94e849f1b75307ce0a"
+  integrity sha512-WQ3AgWCWYSb2yt+IG8mnC6Jdk9Whs7O0gxphblsLvdhSpSTtmu69ZG1Gkb6NuvxsNACwiPV6cNSZNzt0KPsw7g==
+
+"@img/sharp-win32-ia32@0.34.5":
+  version "0.34.5"
+  resolved "https://registry.yarnpkg.com/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.34.5.tgz#0b71166599b049e032f085fb9263e02f4e4788de"
+  integrity sha512-FV9m/7NmeCmSHDD5j4+4pNI8Cp3aW+JvLoXcTUo0IqyjSfAZJ8dIUmijx1qaJsIiU+Hosw6xM5KijAWRJCSgNg==
+
 "@img/sharp-win32-x64@0.34.5":
   version "0.34.5"
   resolved "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.34.5.tgz"
@@ -439,7 +598,7 @@
   dependencies:
     "@babel/runtime" "^7.28.6"
 
-"@mui/material@^7.3.0 || ^9.0.0", "@mui/material@^7.3.10", "@mui/material@^7.3.9":
+"@mui/material@^7.3.9":
   version "7.3.10"
   resolved "https://registry.npmjs.org/@mui/material/-/material-7.3.10.tgz"
   integrity sha512-cHvGOk2ZEfbQt3LnGe0ZKd/ETs9gsUpkW66DCO+GSjMZhpdKU4XsuIr7zJ/B/2XaN8ihxuzHfYAR4zPtCN4RYg==
@@ -478,7 +637,7 @@
     csstype "^3.2.3"
     prop-types "^15.8.1"
 
-"@mui/system@^7.3.0 || ^9.0.0", "@mui/system@^7.3.10":
+"@mui/system@^7.3.10":
   version "7.3.10"
   resolved "https://registry.npmjs.org/@mui/system/-/system-7.3.10.tgz"
   integrity sha512-/sfPpdpJaQn7BSF+avjIdHSYmxHp0UOBYNxSG9QGKfMOD6sLANCpRPCnanq1Pe0lFf0NHkO2iUk0TNzdWC1USQ==
@@ -506,18 +665,6 @@
   dependencies:
     "@babel/runtime" "^7.29.2"
 
-"@mui/utils@^7.3.10":
-  version "7.3.10"
-  resolved "https://registry.npmjs.org/@mui/utils/-/utils-7.3.10.tgz"
-  integrity sha512-7y2eIfy0h7JPz+Yy4pS+wgV68d46PuuxDqKBN4Q8VlPQSsCAGwroMCV6xWyc7g9dvEp8ZNFsknc59GHWO+r6Ow==
-  dependencies:
-    "@babel/runtime" "^7.28.6"
-    "@mui/types" "^7.4.12"
-    "@types/prop-types" "^15.7.15"
-    clsx "^2.1.1"
-    prop-types "^15.8.1"
-    react-is "^19.2.3"
-
 "@mui/utils@9.0.0":
   version "9.0.0"
   resolved "https://registry.npmjs.org/@mui/utils/-/utils-9.0.0.tgz"
@@ -529,6 +676,18 @@
     clsx "^2.1.1"
     prop-types "^15.8.1"
     react-is "^19.2.4"
+
+"@mui/utils@^7.3.10":
+  version "7.3.10"
+  resolved "https://registry.npmjs.org/@mui/utils/-/utils-7.3.10.tgz"
+  integrity sha512-7y2eIfy0h7JPz+Yy4pS+wgV68d46PuuxDqKBN4Q8VlPQSsCAGwroMCV6xWyc7g9dvEp8ZNFsknc59GHWO+r6Ow==
+  dependencies:
+    "@babel/runtime" "^7.28.6"
+    "@mui/types" "^7.4.12"
+    "@types/prop-types" "^15.7.15"
+    clsx "^2.1.1"
+    prop-types "^15.8.1"
+    react-is "^19.2.3"
 
 "@mui/x-date-pickers@^9.0.2":
   version "9.0.4"
@@ -553,6 +712,15 @@
     reselect "^5.1.1"
     use-sync-external-store "^1.6.0"
 
+"@napi-rs/wasm-runtime@^0.2.11":
+  version "0.2.12"
+  resolved "https://registry.yarnpkg.com/@napi-rs/wasm-runtime/-/wasm-runtime-0.2.12.tgz#3e78a8b96e6c33a6c517e1894efbd5385a7cb6f2"
+  integrity sha512-ZVWUcfwY4E/yPitQJl481FjFo3K22D6qF0DuFH6Y/nbnE11GY5uguDxZMGXPQ8WQ0128MXQD7TnfHyK4oWoIJQ==
+  dependencies:
+    "@emnapi/core" "^1.4.3"
+    "@emnapi/runtime" "^1.4.3"
+    "@tybys/wasm-util" "^0.10.0"
+
 "@next/env@16.2.2":
   version "16.2.2"
   resolved "https://registry.npmjs.org/@next/env/-/env-16.2.2.tgz"
@@ -564,6 +732,41 @@
   integrity sha512-IOPbWzDQ+76AtjZioaCjpIY72xNSDMnarZ2GMQ4wjNLvnJEJHqxQwGFhgnIWLV9klb4g/+amg88Tk5OXVpyLTw==
   dependencies:
     fast-glob "3.3.1"
+
+"@next/swc-darwin-arm64@16.2.2":
+  version "16.2.2"
+  resolved "https://registry.yarnpkg.com/@next/swc-darwin-arm64/-/swc-darwin-arm64-16.2.2.tgz#3fef301c711e8c249367a8e5bf6de70fb74a05a4"
+  integrity sha512-B92G3ulrwmkDSEJEp9+XzGLex5wC1knrmCSIylyVeiAtCIfvEJYiN3v5kXPlYt5R4RFlsfO/v++aKV63Acrugg==
+
+"@next/swc-darwin-x64@16.2.2":
+  version "16.2.2"
+  resolved "https://registry.yarnpkg.com/@next/swc-darwin-x64/-/swc-darwin-x64-16.2.2.tgz#729584bfae41fca5e381229a3d1fe0eaf313cc0e"
+  integrity sha512-7ZwSgNKJNQiwW0CKhNm9B1WS2L1Olc4B2XY0hPYCAL3epFnugMhuw5TMWzMilQ3QCZcCHoYm9NGWTHbr5REFxw==
+
+"@next/swc-linux-arm64-gnu@16.2.2":
+  version "16.2.2"
+  resolved "https://registry.yarnpkg.com/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-16.2.2.tgz#edd526da879fe56e4cb82d57aeb5174956c65493"
+  integrity sha512-c3m8kBHMziMgo2fICOP/cd/5YlrxDU5YYjAJeQLyFsCqVF8xjOTH/QYG4a2u48CvvZZSj1eHQfBCbyh7kBr30Q==
+
+"@next/swc-linux-arm64-musl@16.2.2":
+  version "16.2.2"
+  resolved "https://registry.yarnpkg.com/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-16.2.2.tgz#f5990229520663cd759b0eaa426dace2b0510a10"
+  integrity sha512-VKLuscm0P/mIfzt+SDdn2+8TNNJ7f0qfEkA+az7OqQbjzKdBxAHs0UvuiVoCtbwX+dqMEL9U54b5wQ/aN3dHeg==
+
+"@next/swc-linux-x64-gnu@16.2.2":
+  version "16.2.2"
+  resolved "https://registry.yarnpkg.com/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-16.2.2.tgz#49b3fcdf73e0403fde8dc9309488c5dd3d19b587"
+  integrity sha512-kU3OPHJq6sBUjOk7wc5zJ7/lipn8yGldMoAv4z67j6ov6Xo/JvzA7L7LCsyzzsXmgLEhk3Qkpwqaq/1+XpNR3g==
+
+"@next/swc-linux-x64-musl@16.2.2":
+  version "16.2.2"
+  resolved "https://registry.yarnpkg.com/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-16.2.2.tgz#c7fa2e5cb97876efcc8773ae892e426aec1b6f97"
+  integrity sha512-CKXRILyErMtUftp+coGcZ38ZwE/Aqq45VMCcRLr2I4OXKrgxIBDXHnBgeX/UMil0S09i2JXaDL3Q+TN8D/cKmg==
+
+"@next/swc-win32-arm64-msvc@16.2.2":
+  version "16.2.2"
+  resolved "https://registry.yarnpkg.com/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-16.2.2.tgz#4d144d95344d684b62710246b15f306b3ee24341"
+  integrity sha512-sS/jSk5VUoShUqINJFvNjVT7JfR5ORYj/+/ZpOYbbIohv/lQfduWnGAycq2wlknbOql2xOR0DoV0s6Xfcy49+g==
 
 "@next/swc-win32-x64-msvc@16.2.2":
   version "16.2.2"
@@ -578,7 +781,7 @@
     "@nodelib/fs.stat" "2.0.5"
     run-parallel "^1.1.9"
 
-"@nodelib/fs.stat@^2.0.2", "@nodelib/fs.stat@2.0.5":
+"@nodelib/fs.stat@2.0.5", "@nodelib/fs.stat@^2.0.2":
   version "2.0.5"
   resolved "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz"
   integrity sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==
@@ -595,6 +798,66 @@
   version "1.0.39"
   resolved "https://registry.npmjs.org/@nolyfill/is-core-module/-/is-core-module-1.0.39.tgz"
   integrity sha512-nn5ozdjYQpUCZlWGuxcJY/KpxkWQs4DcbMCmKojjyrYDEAGy4Ce19NN4v5MduafTwJlbKc99UA8YhSVqq9yPZA==
+
+"@parcel/watcher-android-arm64@2.5.6":
+  version "2.5.6"
+  resolved "https://registry.yarnpkg.com/@parcel/watcher-android-arm64/-/watcher-android-arm64-2.5.6.tgz#5f32e0dba356f4ac9a11068d2a5c134ca3ba6564"
+  integrity sha512-YQxSS34tPF/6ZG7r/Ih9xy+kP/WwediEUsqmtf0cuCV5TPPKw/PQHRhueUo6JdeFJaqV3pyjm0GdYjZotbRt/A==
+
+"@parcel/watcher-darwin-arm64@2.5.6":
+  version "2.5.6"
+  resolved "https://registry.yarnpkg.com/@parcel/watcher-darwin-arm64/-/watcher-darwin-arm64-2.5.6.tgz#88d3e720b59b1eceffce98dac46d7c40e8be5e8e"
+  integrity sha512-Z2ZdrnwyXvvvdtRHLmM4knydIdU9adO3D4n/0cVipF3rRiwP+3/sfzpAwA/qKFL6i1ModaabkU7IbpeMBgiVEA==
+
+"@parcel/watcher-darwin-x64@2.5.6":
+  version "2.5.6"
+  resolved "https://registry.yarnpkg.com/@parcel/watcher-darwin-x64/-/watcher-darwin-x64-2.5.6.tgz#bf05d76a78bc15974f15ec3671848698b0838063"
+  integrity sha512-HgvOf3W9dhithcwOWX9uDZyn1lW9R+7tPZ4sug+NGrGIo4Rk1hAXLEbcH1TQSqxts0NYXXlOWqVpvS1SFS4fRg==
+
+"@parcel/watcher-freebsd-x64@2.5.6":
+  version "2.5.6"
+  resolved "https://registry.yarnpkg.com/@parcel/watcher-freebsd-x64/-/watcher-freebsd-x64-2.5.6.tgz#8bc26e9848e7303ac82922a5ae1b1ef1bdb48a53"
+  integrity sha512-vJVi8yd/qzJxEKHkeemh7w3YAn6RJCtYlE4HPMoVnCpIXEzSrxErBW5SJBgKLbXU3WdIpkjBTeUNtyBVn8TRng==
+
+"@parcel/watcher-linux-arm-glibc@2.5.6":
+  version "2.5.6"
+  resolved "https://registry.yarnpkg.com/@parcel/watcher-linux-arm-glibc/-/watcher-linux-arm-glibc-2.5.6.tgz#1328fee1deb0c2d7865079ef53a2ba4cc2f8b40a"
+  integrity sha512-9JiYfB6h6BgV50CCfasfLf/uvOcJskMSwcdH1PHH9rvS1IrNy8zad6IUVPVUfmXr+u+Km9IxcfMLzgdOudz9EQ==
+
+"@parcel/watcher-linux-arm-musl@2.5.6":
+  version "2.5.6"
+  resolved "https://registry.yarnpkg.com/@parcel/watcher-linux-arm-musl/-/watcher-linux-arm-musl-2.5.6.tgz#bad0f45cb3e2157746db8b9d22db6a125711f152"
+  integrity sha512-Ve3gUCG57nuUUSyjBq/MAM0CzArtuIOxsBdQ+ftz6ho8n7s1i9E1Nmk/xmP323r2YL0SONs1EuwqBp2u1k5fxg==
+
+"@parcel/watcher-linux-arm64-glibc@2.5.6":
+  version "2.5.6"
+  resolved "https://registry.yarnpkg.com/@parcel/watcher-linux-arm64-glibc/-/watcher-linux-arm64-glibc-2.5.6.tgz#b75913fbd501d9523c5f35d420957bf7d0204809"
+  integrity sha512-f2g/DT3NhGPdBmMWYoxixqYr3v/UXcmLOYy16Bx0TM20Tchduwr4EaCbmxh1321TABqPGDpS8D/ggOTaljijOA==
+
+"@parcel/watcher-linux-arm64-musl@2.5.6":
+  version "2.5.6"
+  resolved "https://registry.yarnpkg.com/@parcel/watcher-linux-arm64-musl/-/watcher-linux-arm64-musl-2.5.6.tgz#da5621a6a576070c8c0de60dea8b46dc9c3827d4"
+  integrity sha512-qb6naMDGlbCwdhLj6hgoVKJl2odL34z2sqkC7Z6kzir8b5W65WYDpLB6R06KabvZdgoHI/zxke4b3zR0wAbDTA==
+
+"@parcel/watcher-linux-x64-glibc@2.5.6":
+  version "2.5.6"
+  resolved "https://registry.yarnpkg.com/@parcel/watcher-linux-x64-glibc/-/watcher-linux-x64-glibc-2.5.6.tgz#ce437accdc4b30f93a090b4a221fd95cd9b89639"
+  integrity sha512-kbT5wvNQlx7NaGjzPFu8nVIW1rWqV780O7ZtkjuWaPUgpv2NMFpjYERVi0UYj1msZNyCzGlaCWEtzc+exjMGbQ==
+
+"@parcel/watcher-linux-x64-musl@2.5.6":
+  version "2.5.6"
+  resolved "https://registry.yarnpkg.com/@parcel/watcher-linux-x64-musl/-/watcher-linux-x64-musl-2.5.6.tgz#02400c54b4a67efcc7e2327b249711920ac969e2"
+  integrity sha512-1JRFeC+h7RdXwldHzTsmdtYR/Ku8SylLgTU/reMuqdVD7CtLwf0VR1FqeprZ0eHQkO0vqsbvFLXUmYm/uNKJBg==
+
+"@parcel/watcher-win32-arm64@2.5.6":
+  version "2.5.6"
+  resolved "https://registry.yarnpkg.com/@parcel/watcher-win32-arm64/-/watcher-win32-arm64-2.5.6.tgz#caae3d3c7583ca0a7171e6bd142c34d20ea1691e"
+  integrity sha512-3ukyebjc6eGlw9yRt678DxVF7rjXatWiHvTXqphZLvo7aC5NdEgFufVwjFfY51ijYEWpXbqF5jtrK275z52D4Q==
+
+"@parcel/watcher-win32-ia32@2.5.6":
+  version "2.5.6"
+  resolved "https://registry.yarnpkg.com/@parcel/watcher-win32-ia32/-/watcher-win32-ia32-2.5.6.tgz#9ac922550896dfe47bfc5ae3be4f1bcaf8155d6d"
+  integrity sha512-k35yLp1ZMwwee3Ez/pxBi5cf4AoBKYXj00CZ80jUz5h8prpiaQsiRPKQMxoLstNuqe2vR4RNPEAEcjEFzhEz/g==
 
 "@parcel/watcher-win32-x64@2.5.6":
   version "2.5.6"
@@ -645,6 +908,61 @@
   resolved "https://registry.npmjs.org/@standard-schema/utils/-/utils-0.3.0.tgz"
   integrity sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g==
 
+"@swc/core-darwin-arm64@1.15.30":
+  version "1.15.30"
+  resolved "https://registry.yarnpkg.com/@swc/core-darwin-arm64/-/core-darwin-arm64-1.15.30.tgz#23447f1c30c9155fe35602de4392b4ecfa0a54cc"
+  integrity sha512-VvpP+vq08HmGYewMWvrdsxh9s2lthz/808zXm8Yu5kaqeR8Yia2b0eYXleHQ3VAjoStUDk6LzTheBW9KXYQdMA==
+
+"@swc/core-darwin-x64@1.15.30":
+  version "1.15.30"
+  resolved "https://registry.yarnpkg.com/@swc/core-darwin-x64/-/core-darwin-x64-1.15.30.tgz#16e6e35fff5b07c712d8af44783da59ac64ad5cf"
+  integrity sha512-WiJA0hiZI3nwQAO6mu5RqigtWGDtth4Hiq6rbZxAaQyhIcqKIg5IoMRc1Y071lrNJn29eEDMC86Rq58xgUxlDg==
+
+"@swc/core-linux-arm-gnueabihf@1.15.30":
+  version "1.15.30"
+  resolved "https://registry.yarnpkg.com/@swc/core-linux-arm-gnueabihf/-/core-linux-arm-gnueabihf-1.15.30.tgz#abce7de734301109a7df23c22f6b6d233e3b9de9"
+  integrity sha512-YANuFUo48kIT6plJgCD0keae9HFXfjxsbvsgevqc0hr/07X/p7sAWTFOGYEc2SXcASaK7UvuQqzlbW8pr7R79g==
+
+"@swc/core-linux-arm64-gnu@1.15.30":
+  version "1.15.30"
+  resolved "https://registry.yarnpkg.com/@swc/core-linux-arm64-gnu/-/core-linux-arm64-gnu-1.15.30.tgz#9a4e418cdbbfe64506dd12469a553c07e1924fef"
+  integrity sha512-VndG8jaR4ugY6u+iVOT0Q+d2fZd7sLgjPgN8W/Le+3EbZKl+cRfFxV7Eoz4gfLqhmneZPdcIzf9T3LkgkmqNLg==
+
+"@swc/core-linux-arm64-musl@1.15.30":
+  version "1.15.30"
+  resolved "https://registry.yarnpkg.com/@swc/core-linux-arm64-musl/-/core-linux-arm64-musl-1.15.30.tgz#4cd68ccb2af71c3ec539b15aa15c8fd304833d26"
+  integrity sha512-1SYGs2l0Yyyi0pR/P/NKz/x0kqxkoiw+BXeJjLUdecSk/KasncWlJrc6hOvFSgKHOBrzgM5jwuluKtlT8dnrcA==
+
+"@swc/core-linux-ppc64-gnu@1.15.30":
+  version "1.15.30"
+  resolved "https://registry.yarnpkg.com/@swc/core-linux-ppc64-gnu/-/core-linux-ppc64-gnu-1.15.30.tgz#561997d3c5f392db7e3473cb4bbc43e6d6b1160c"
+  integrity sha512-TXREtiXeRhbfDFbmhnkIsXpKfzbfT73YkV2ZF6w0sfxgjC5zI2ZAbaCOq25qxvegofj2K93DtOpm9RLaBgqR2g==
+
+"@swc/core-linux-s390x-gnu@1.15.30":
+  version "1.15.30"
+  resolved "https://registry.yarnpkg.com/@swc/core-linux-s390x-gnu/-/core-linux-s390x-gnu-1.15.30.tgz#d6f1d5dceca794909305584cb69f80dd91820410"
+  integrity sha512-DCR2YYeyd6DQE4OuDhImouuNcjXEiEdnn1Y0DyGteugPEDvVuvYk8Xddi+4o2SgWH6jiW8/I+3emZvbep1NC+g==
+
+"@swc/core-linux-x64-gnu@1.15.30":
+  version "1.15.30"
+  resolved "https://registry.yarnpkg.com/@swc/core-linux-x64-gnu/-/core-linux-x64-gnu-1.15.30.tgz#c3e91c60f265a62cec60145f0d2d931feb1cf41a"
+  integrity sha512-5Pizw3NgfOJ5BJOBK8TIRa59xFW2avESTOBDPTAYwZYa1JNDs+KMF9lUfjJiJLM5HiMs/wPheA9eiT0q9m2AoA==
+
+"@swc/core-linux-x64-musl@1.15.30":
+  version "1.15.30"
+  resolved "https://registry.yarnpkg.com/@swc/core-linux-x64-musl/-/core-linux-x64-musl-1.15.30.tgz#3fd112e617a951438f73930b514adf19375067fb"
+  integrity sha512-qyqydP/wyH8alcIP4a2hnGSjHLJjm9H7yDFup+CPy9oTahFgLLwnNcv5UHXqO2Qs3AIND+cls5f/Bb6hqpxdgA==
+
+"@swc/core-win32-arm64-msvc@1.15.30":
+  version "1.15.30"
+  resolved "https://registry.yarnpkg.com/@swc/core-win32-arm64-msvc/-/core-win32-arm64-msvc-1.15.30.tgz#d005dce92e4ec1b0a7898667c9cf5e5215e4631c"
+  integrity sha512-CaQENgDHVGOg1mSF5sQVgvfFHG9kjMor2rkLMLeLOkfZYNj13ppnJ9+lfaBZLZUMMbnlGQnavCJb8PVBUOso7Q==
+
+"@swc/core-win32-ia32-msvc@1.15.30":
+  version "1.15.30"
+  resolved "https://registry.yarnpkg.com/@swc/core-win32-ia32-msvc/-/core-win32-ia32-msvc-1.15.30.tgz#67ebfaa22266835a3d82776014c2f428346062bd"
+  integrity sha512-30VdLeGk6fugiUs/kUdJ/pAg7z/zpvVbR11RH60jZ0Z42WIeIniYx0rLEWN7h/pKJ3CopqsQ3RsogCAkRKiA2g==
+
 "@swc/core-win32-x64-msvc@1.15.30":
   version "1.15.30"
   resolved "https://registry.npmjs.org/@swc/core-win32-x64-msvc/-/core-win32-x64-msvc-1.15.30.tgz"
@@ -676,7 +994,7 @@
   resolved "https://registry.npmjs.org/@swc/counter/-/counter-0.1.3.tgz"
   integrity sha512-e2BR4lsJkkRlKZ/qCHPw9ZaSxc0MVUd7gtbtaB7aMvHeJVYe8sOB8DBZkP2DtISHGSku9sCK6T6cnY0CtXrOCQ==
 
-"@swc/helpers@>=0.5.17", "@swc/helpers@0.5.15":
+"@swc/helpers@0.5.15":
   version "0.5.15"
   resolved "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.15.tgz"
   integrity sha512-JQ5TuMi45Owi4/BIMAJBoSQoOJu12oOk/gADqlcUL9JEdHB8vyjUSsxqeNXnmXHjYKMi2WcYtezGEEhqUI/E2g==
@@ -689,6 +1007,13 @@
   integrity sha512-lyMwd7WGgG79RS7EERZV3T8wMdmPq3xwyg+1nmAM64kIhx5yl+juO2PYIHb7vTiPgPCj8LYjsNV2T5wiQHUEaw==
   dependencies:
     "@swc/counter" "^0.1.3"
+
+"@tybys/wasm-util@^0.10.0":
+  version "0.10.2"
+  resolved "https://registry.yarnpkg.com/@tybys/wasm-util/-/wasm-util-0.10.2.tgz#12b3a1b33db1f9cad4ddff1f604ab7dd00bf464e"
+  integrity sha512-RoBvJ2X0wuKlWFIjrwffGw1IqZHKQqzIchKaadZZfnNpsAYp2mM0h36JtPCjNDAHGgYez/15uMBpfGwchhiMgg==
+  dependencies:
+    tslib "^2.4.0"
 
 "@types/estree@^1.0.6":
   version "1.0.8"
@@ -732,7 +1057,7 @@
   resolved "https://registry.npmjs.org/@types/react-transition-group/-/react-transition-group-4.4.12.tgz"
   integrity sha512-8TV6R3h2j7a91c+1DXdJi3Syo69zzIZbz7Lg5tORM5LEJG7X/E6a1V3drRyBRZq7/utz7A+c4OgYLiLcYGHG6w==
 
-"@types/react@*", "@types/react@^17.0.0 || ^18.0.0 || ^19.0.0", "@types/react@^19", "@types/react@^19.2.0", "@types/react@>=18.0.0":
+"@types/react@^19":
   version "19.2.14"
   resolved "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz"
   integrity sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==
@@ -753,7 +1078,7 @@
     natural-compare "^1.4.0"
     ts-api-utils "^2.5.0"
 
-"@typescript-eslint/parser@^8.59.0", "@typescript-eslint/parser@8.59.0":
+"@typescript-eslint/parser@8.59.0":
   version "8.59.0"
   resolved "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.59.0.tgz"
   integrity sha512-TI1XGwKbDpo9tRW8UDIXCOeLk55qe9ZFGs8MTKU6/M08HWTw52DD/IYhfQtOEhEdPhLMT26Ka/x7p70nd3dzDg==
@@ -781,7 +1106,7 @@
     "@typescript-eslint/types" "8.59.0"
     "@typescript-eslint/visitor-keys" "8.59.0"
 
-"@typescript-eslint/tsconfig-utils@^8.59.0", "@typescript-eslint/tsconfig-utils@8.59.0":
+"@typescript-eslint/tsconfig-utils@8.59.0", "@typescript-eslint/tsconfig-utils@^8.59.0":
   version "8.59.0"
   resolved "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.59.0.tgz"
   integrity sha512-91Sbl3s4Kb3SybliIY6muFBmHVv+pYXfybC4Oolp3dvk8BvIE3wOPc+403CWIT7mJNkfQRGtdqghzs2+Z91Tqg==
@@ -797,7 +1122,7 @@
     debug "^4.4.3"
     ts-api-utils "^2.5.0"
 
-"@typescript-eslint/types@^8.59.0", "@typescript-eslint/types@8.59.0":
+"@typescript-eslint/types@8.59.0", "@typescript-eslint/types@^8.59.0":
   version "8.59.0"
   resolved "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.59.0.tgz"
   integrity sha512-nLzdsT1gdOgFxxxwrlNVUBzSNBEEHJ86bblmk4QAS6stfig7rcJzWKqCyxFy3YRRHXDWEkb2NralA1nOYkkm/A==
@@ -835,6 +1160,98 @@
     "@typescript-eslint/types" "8.59.0"
     eslint-visitor-keys "^5.0.0"
 
+"@unrs/resolver-binding-android-arm-eabi@1.11.1":
+  version "1.11.1"
+  resolved "https://registry.yarnpkg.com/@unrs/resolver-binding-android-arm-eabi/-/resolver-binding-android-arm-eabi-1.11.1.tgz#9f5b04503088e6a354295e8ea8fe3cb99e43af81"
+  integrity sha512-ppLRUgHVaGRWUx0R0Ut06Mjo9gBaBkg3v/8AxusGLhsIotbBLuRk51rAzqLC8gq6NyyAojEXglNjzf6R948DNw==
+
+"@unrs/resolver-binding-android-arm64@1.11.1":
+  version "1.11.1"
+  resolved "https://registry.yarnpkg.com/@unrs/resolver-binding-android-arm64/-/resolver-binding-android-arm64-1.11.1.tgz#7414885431bd7178b989aedc4d25cccb3865bc9f"
+  integrity sha512-lCxkVtb4wp1v+EoN+HjIG9cIIzPkX5OtM03pQYkG+U5O/wL53LC4QbIeazgiKqluGeVEeBlZahHalCaBvU1a2g==
+
+"@unrs/resolver-binding-darwin-arm64@1.11.1":
+  version "1.11.1"
+  resolved "https://registry.yarnpkg.com/@unrs/resolver-binding-darwin-arm64/-/resolver-binding-darwin-arm64-1.11.1.tgz#b4a8556f42171fb9c9f7bac8235045e82aa0cbdf"
+  integrity sha512-gPVA1UjRu1Y/IsB/dQEsp2V1pm44Of6+LWvbLc9SDk1c2KhhDRDBUkQCYVWe6f26uJb3fOK8saWMgtX8IrMk3g==
+
+"@unrs/resolver-binding-darwin-x64@1.11.1":
+  version "1.11.1"
+  resolved "https://registry.yarnpkg.com/@unrs/resolver-binding-darwin-x64/-/resolver-binding-darwin-x64-1.11.1.tgz#fd4d81257b13f4d1a083890a6a17c00de571f0dc"
+  integrity sha512-cFzP7rWKd3lZaCsDze07QX1SC24lO8mPty9vdP+YVa3MGdVgPmFc59317b2ioXtgCMKGiCLxJ4HQs62oz6GfRQ==
+
+"@unrs/resolver-binding-freebsd-x64@1.11.1":
+  version "1.11.1"
+  resolved "https://registry.yarnpkg.com/@unrs/resolver-binding-freebsd-x64/-/resolver-binding-freebsd-x64-1.11.1.tgz#d2513084d0f37c407757e22f32bd924a78cfd99b"
+  integrity sha512-fqtGgak3zX4DCB6PFpsH5+Kmt/8CIi4Bry4rb1ho6Av2QHTREM+47y282Uqiu3ZRF5IQioJQ5qWRV6jduA+iGw==
+
+"@unrs/resolver-binding-linux-arm-gnueabihf@1.11.1":
+  version "1.11.1"
+  resolved "https://registry.yarnpkg.com/@unrs/resolver-binding-linux-arm-gnueabihf/-/resolver-binding-linux-arm-gnueabihf-1.11.1.tgz#844d2605d057488d77fab09705f2866b86164e0a"
+  integrity sha512-u92mvlcYtp9MRKmP+ZvMmtPN34+/3lMHlyMj7wXJDeXxuM0Vgzz0+PPJNsro1m3IZPYChIkn944wW8TYgGKFHw==
+
+"@unrs/resolver-binding-linux-arm-musleabihf@1.11.1":
+  version "1.11.1"
+  resolved "https://registry.yarnpkg.com/@unrs/resolver-binding-linux-arm-musleabihf/-/resolver-binding-linux-arm-musleabihf-1.11.1.tgz#204892995cefb6bd1d017d52d097193bc61ddad3"
+  integrity sha512-cINaoY2z7LVCrfHkIcmvj7osTOtm6VVT16b5oQdS4beibX2SYBwgYLmqhBjA1t51CarSaBuX5YNsWLjsqfW5Cw==
+
+"@unrs/resolver-binding-linux-arm64-gnu@1.11.1":
+  version "1.11.1"
+  resolved "https://registry.yarnpkg.com/@unrs/resolver-binding-linux-arm64-gnu/-/resolver-binding-linux-arm64-gnu-1.11.1.tgz#023eb0c3aac46066a10be7a3f362e7b34f3bdf9d"
+  integrity sha512-34gw7PjDGB9JgePJEmhEqBhWvCiiWCuXsL9hYphDF7crW7UgI05gyBAi6MF58uGcMOiOqSJ2ybEeCvHcq0BCmQ==
+
+"@unrs/resolver-binding-linux-arm64-musl@1.11.1":
+  version "1.11.1"
+  resolved "https://registry.yarnpkg.com/@unrs/resolver-binding-linux-arm64-musl/-/resolver-binding-linux-arm64-musl-1.11.1.tgz#9e6f9abb06424e3140a60ac996139786f5d99be0"
+  integrity sha512-RyMIx6Uf53hhOtJDIamSbTskA99sPHS96wxVE/bJtePJJtpdKGXO1wY90oRdXuYOGOTuqjT8ACccMc4K6QmT3w==
+
+"@unrs/resolver-binding-linux-ppc64-gnu@1.11.1":
+  version "1.11.1"
+  resolved "https://registry.yarnpkg.com/@unrs/resolver-binding-linux-ppc64-gnu/-/resolver-binding-linux-ppc64-gnu-1.11.1.tgz#b111417f17c9d1b02efbec8e08398f0c5527bb44"
+  integrity sha512-D8Vae74A4/a+mZH0FbOkFJL9DSK2R6TFPC9M+jCWYia/q2einCubX10pecpDiTmkJVUH+y8K3BZClycD8nCShA==
+
+"@unrs/resolver-binding-linux-riscv64-gnu@1.11.1":
+  version "1.11.1"
+  resolved "https://registry.yarnpkg.com/@unrs/resolver-binding-linux-riscv64-gnu/-/resolver-binding-linux-riscv64-gnu-1.11.1.tgz#92ffbf02748af3e99873945c9a8a5ead01d508a9"
+  integrity sha512-frxL4OrzOWVVsOc96+V3aqTIQl1O2TjgExV4EKgRY09AJ9leZpEg8Ak9phadbuX0BA4k8U5qtvMSQQGGmaJqcQ==
+
+"@unrs/resolver-binding-linux-riscv64-musl@1.11.1":
+  version "1.11.1"
+  resolved "https://registry.yarnpkg.com/@unrs/resolver-binding-linux-riscv64-musl/-/resolver-binding-linux-riscv64-musl-1.11.1.tgz#0bec6f1258fc390e6b305e9ff44256cb207de165"
+  integrity sha512-mJ5vuDaIZ+l/acv01sHoXfpnyrNKOk/3aDoEdLO/Xtn9HuZlDD6jKxHlkN8ZhWyLJsRBxfv9GYM2utQ1SChKew==
+
+"@unrs/resolver-binding-linux-s390x-gnu@1.11.1":
+  version "1.11.1"
+  resolved "https://registry.yarnpkg.com/@unrs/resolver-binding-linux-s390x-gnu/-/resolver-binding-linux-s390x-gnu-1.11.1.tgz#577843a084c5952f5906770633ccfb89dac9bc94"
+  integrity sha512-kELo8ebBVtb9sA7rMe1Cph4QHreByhaZ2QEADd9NzIQsYNQpt9UkM9iqr2lhGr5afh885d/cB5QeTXSbZHTYPg==
+
+"@unrs/resolver-binding-linux-x64-gnu@1.11.1":
+  version "1.11.1"
+  resolved "https://registry.yarnpkg.com/@unrs/resolver-binding-linux-x64-gnu/-/resolver-binding-linux-x64-gnu-1.11.1.tgz#36fb318eebdd690f6da32ac5e0499a76fa881935"
+  integrity sha512-C3ZAHugKgovV5YvAMsxhq0gtXuwESUKc5MhEtjBpLoHPLYM+iuwSj3lflFwK3DPm68660rZ7G8BMcwSro7hD5w==
+
+"@unrs/resolver-binding-linux-x64-musl@1.11.1":
+  version "1.11.1"
+  resolved "https://registry.yarnpkg.com/@unrs/resolver-binding-linux-x64-musl/-/resolver-binding-linux-x64-musl-1.11.1.tgz#bfb9af75f783f98f6a22c4244214efe4df1853d6"
+  integrity sha512-rV0YSoyhK2nZ4vEswT/QwqzqQXw5I6CjoaYMOX0TqBlWhojUf8P94mvI7nuJTeaCkkds3QE4+zS8Ko+GdXuZtA==
+
+"@unrs/resolver-binding-wasm32-wasi@1.11.1":
+  version "1.11.1"
+  resolved "https://registry.yarnpkg.com/@unrs/resolver-binding-wasm32-wasi/-/resolver-binding-wasm32-wasi-1.11.1.tgz#752c359dd875684b27429500d88226d7cc72f71d"
+  integrity sha512-5u4RkfxJm+Ng7IWgkzi3qrFOvLvQYnPBmjmZQ8+szTK/b31fQCnleNl1GgEt7nIsZRIf5PLhPwT0WM+q45x/UQ==
+  dependencies:
+    "@napi-rs/wasm-runtime" "^0.2.11"
+
+"@unrs/resolver-binding-win32-arm64-msvc@1.11.1":
+  version "1.11.1"
+  resolved "https://registry.yarnpkg.com/@unrs/resolver-binding-win32-arm64-msvc/-/resolver-binding-win32-arm64-msvc-1.11.1.tgz#ce5735e600e4c2fbb409cd051b3b7da4a399af35"
+  integrity sha512-nRcz5Il4ln0kMhfL8S3hLkxI85BXs3o8EYoattsJNdsX4YUU89iOkVn7g0VHSRxFuVMdM4Q1jEpIId1Ihim/Uw==
+
+"@unrs/resolver-binding-win32-ia32-msvc@1.11.1":
+  version "1.11.1"
+  resolved "https://registry.yarnpkg.com/@unrs/resolver-binding-win32-ia32-msvc/-/resolver-binding-win32-ia32-msvc-1.11.1.tgz#72fc57bc7c64ec5c3de0d64ee0d1810317bc60a6"
+  integrity sha512-DCEI6t5i1NmAZp6pFonpD5m7i6aFrpofcp4LA2i8IIq60Jyo28hamKBxNrZcyOwVOZkgsRp9O2sXWBWP8MnvIQ==
+
 "@unrs/resolver-binding-win32-x64-msvc@1.11.1":
   version "1.11.1"
   resolved "https://registry.npmjs.org/@unrs/resolver-binding-win32-x64-msvc/-/resolver-binding-win32-x64-msvc-1.11.1.tgz"
@@ -845,7 +1262,7 @@ acorn-jsx@^5.3.2:
   resolved "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz"
   integrity sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==
 
-"acorn@^6.0.0 || ^7.0.0 || ^8.0.0", acorn@^8.15.0:
+acorn@^8.15.0:
   version "8.16.0"
   resolved "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz"
   integrity sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==
@@ -884,12 +1301,7 @@ ansi-styles@^4.1.0:
   dependencies:
     color-convert "^2.0.1"
 
-ansi-styles@^6.2.1:
-  version "6.2.3"
-  resolved "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz"
-  integrity sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==
-
-ansi-styles@^6.2.3:
+ansi-styles@^6.2.1, ansi-styles@^6.2.3:
   version "6.2.3"
   resolved "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz"
   integrity sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==
@@ -1082,7 +1494,7 @@ braces@^3.0.3:
   dependencies:
     fill-range "^7.1.1"
 
-browserslist@^4.24.0, "browserslist@>= 4.21.0":
+browserslist@^4.24.0:
   version "4.28.2"
   resolved "https://registry.npmjs.org/browserslist/-/browserslist-4.28.2.tgz"
   integrity sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==
@@ -1270,7 +1682,7 @@ data-view-byte-offset@^1.0.1:
     es-errors "^1.3.0"
     is-data-view "^1.0.1"
 
-"date-fns@^2.25.0 || ^3.2.0 || ^4.0.0", date-fns@^4.1.0:
+date-fns@^4.1.0:
   version "4.1.0"
   resolved "https://registry.npmjs.org/date-fns/-/date-fns-4.1.0.tgz"
   integrity sha512-Ukq0owbQXxa/U3EGtsdVBkR1w7KOQ5gIBqdH2hkvknzZPYvBxb/aa6E8L7tmjFtkwZBu3UXBbjIgPo/Ez4xaNg==
@@ -1552,7 +1964,7 @@ eslint-module-utils@^2.12.1:
   dependencies:
     debug "^3.2.7"
 
-eslint-plugin-import@*, eslint-plugin-import@^2.32.0:
+eslint-plugin-import@^2.32.0:
   version "2.32.0"
   resolved "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.32.0.tgz"
   integrity sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==
@@ -1656,7 +2068,7 @@ eslint-visitor-keys@^5.0.0:
   resolved "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz"
   integrity sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==
 
-eslint@*, "eslint@^2 || ^3 || ^4 || ^5 || ^6 || ^7.2.0 || ^8 || ^9", "eslint@^3 || ^4 || ^5 || ^6 || ^7 || ^8 || ^9", "eslint@^3 || ^4 || ^5 || ^6 || ^7 || ^8 || ^9.7", "eslint@^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0 || ^9.0.0 || ^10.0.0", "eslint@^6.0.0 || ^7.0.0 || >=8.0.0", "eslint@^8.57.0 || ^9.0.0 || ^10.0.0", eslint@^9, eslint@>=9.0.0:
+eslint@^9:
   version "9.39.4"
   resolved "https://registry.npmjs.org/eslint/-/eslint-9.39.4.tgz"
   integrity sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==
@@ -1926,15 +2338,15 @@ glob-parent@^6.0.2:
   dependencies:
     is-glob "^4.0.3"
 
-globals@^14.0.0:
-  version "14.0.0"
-  resolved "https://registry.npmjs.org/globals/-/globals-14.0.0.tgz"
-  integrity sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==
-
 globals@16.4.0:
   version "16.4.0"
   resolved "https://registry.npmjs.org/globals/-/globals-16.4.0.tgz"
   integrity sha512-ob/2LcVVaVGCYN+r14cnwnoDPUufjiYgSqRhiFD0Q1iI4Odora5RE8Iv1D24hAz5oMophRGkGz+yuvQmmUMnMw==
+
+globals@^14.0.0:
+  version "14.0.0"
+  resolved "https://registry.npmjs.org/globals/-/globals-14.0.0.tgz"
+  integrity sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==
 
 globalthis@^1.0.4:
   version "1.0.4"
@@ -2542,7 +2954,7 @@ next-intl@^4.9.0:
     po-parser "^2.1.1"
     use-intl "^4.9.1"
 
-"next@^12.0.0 || ^13.0.0 || ^14.0.0 || ^15.0.0 || ^16.0.0", next@16.2.2:
+next@16.2.2:
   version "16.2.2"
   resolved "https://registry.npmjs.org/next/-/next-16.2.2.tgz"
   integrity sha512-i6AJdyVa4oQjyvX/6GeER8dpY/xlIV+4NMv/svykcLtURJSy/WzDnnUk/TM4d0uewFHK7xSQz4TbIwPgjky+3A==
@@ -2739,7 +3151,7 @@ picomatch@^2.3.1:
   resolved "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz"
   integrity sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==
 
-"picomatch@^3 || ^4", picomatch@^4.0.3, picomatch@^4.0.4:
+picomatch@^4.0.3, picomatch@^4.0.4:
   version "4.0.4"
   resolved "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz"
   integrity sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==
@@ -2797,24 +3209,19 @@ queue-microtask@^1.2.2:
   resolved "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz"
   integrity sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==
 
-"react-dom@^17.0.0 || ^18.0.0 || ^19.0.0", "react-dom@^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0", react-dom@>=16.6.0, react-dom@19.2.4:
+react-dom@19.2.4:
   version "19.2.4"
   resolved "https://registry.npmjs.org/react-dom/-/react-dom-19.2.4.tgz"
   integrity sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ==
   dependencies:
     scheduler "^0.27.0"
 
-react-hook-form@^7.55.0, react-hook-form@^7.72.1:
+react-hook-form@^7.72.1:
   version "7.73.1"
   resolved "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.73.1.tgz"
   integrity sha512-VAfVYOPcx3piiEVQy95vyFmBwbVUsP/AUIN+mpFG8h11yshDd444nn0VyfaGWSRnhOLVgiDu7HIuBtAIzxn9dA==
 
-react-is@^16.13.1:
-  version "16.13.1"
-  resolved "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz"
-  integrity sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==
-
-react-is@^16.7.0:
+react-is@^16.13.1, react-is@^16.7.0:
   version "16.13.1"
   resolved "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz"
   integrity sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==
@@ -2834,7 +3241,7 @@ react-transition-group@^4.4.5:
     loose-envify "^1.4.0"
     prop-types "^15.6.2"
 
-"react@^16.8.0 || ^17 || ^18 || ^19", "react@^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0", "react@^16.8.0 || ^17.0.0 || ^18.0.0 || >=19.0.0-rc <19.0.0 || ^19.0.0", "react@^17.0.0 || ^18.0.0 || ^19.0.0", "react@^17.0.0 || ^18.0.0 || >=19.0.0-rc <19.0.0 || ^19.0.0", "react@^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0", react@^19.2.4, "react@>= 16.8.0 || 17.x.x || ^18.0.0-0 || ^19.0.0-0", react@>=16.6.0, react@>=16.8.0, react@>=18.0.0, react@19.2.4:
+react@19.2.4:
   version "19.2.4"
   resolved "https://registry.npmjs.org/react/-/react-19.2.4.tgz"
   integrity sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==
@@ -2895,19 +3302,7 @@ resolve@^1.19.0:
     path-parse "^1.0.7"
     supports-preserve-symlinks-flag "^1.0.0"
 
-resolve@^2.0.0-next.5:
-  version "2.0.0-next.6"
-  resolved "https://registry.npmjs.org/resolve/-/resolve-2.0.0-next.6.tgz"
-  integrity sha512-3JmVl5hMGtJ3kMmB3zi3DL25KfkCEyy3Tw7Gmw7z5w8M9WlwoPFnIvwChzu1+cF3iaK3sp18hhPz8ANeimdJfA==
-  dependencies:
-    es-errors "^1.3.0"
-    is-core-module "^2.16.1"
-    node-exports-info "^1.6.0"
-    object-keys "^1.1.1"
-    path-parse "^1.0.7"
-    supports-preserve-symlinks-flag "^1.0.0"
-
-resolve@^2.0.0-next.6:
+resolve@^2.0.0-next.5, resolve@^2.0.0-next.6:
   version "2.0.0-next.6"
   resolved "https://registry.npmjs.org/resolve/-/resolve-2.0.0-next.6.tgz"
   integrity sha512-3JmVl5hMGtJ3kMmB3zi3DL25KfkCEyy3Tw7Gmw7z5w8M9WlwoPFnIvwChzu1+cF3iaK3sp18hhPz8ANeimdJfA==
@@ -2972,7 +3367,7 @@ safe-regex-test@^1.0.3, safe-regex-test@^1.1.0:
     es-errors "^1.3.0"
     is-regex "^1.2.1"
 
-sass@^1.3.0, sass@^1.99.0:
+sass@^1.99.0:
   version "1.99.0"
   resolved "https://registry.npmjs.org/sass/-/sass-1.99.0.tgz"
   integrity sha512-kgW13M54DUB7IsIRM5LvJkNlpH+WhMpooUcaWGFARkF1Tc82v9mIWkCbCYf+MBvpIUBSeSOTilpZjEPr2VYE6Q==
@@ -2993,12 +3388,7 @@ semver@^6.3.1:
   resolved "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz"
   integrity sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==
 
-semver@^7.7.1:
-  version "7.7.4"
-  resolved "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz"
-  integrity sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==
-
-semver@^7.7.3:
+semver@^7.7.1, semver@^7.7.3:
   version "7.7.4"
   resolved "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz"
   integrity sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==
@@ -3141,7 +3531,7 @@ slice-ansi@^8.0.0:
     ansi-styles "^6.2.3"
     is-fullwidth-code-point "^5.1.0"
 
-source-map-js@^1.0.2, "source-map-js@>=0.6.2 <2.0.0":
+"source-map-js@>=0.6.2 <2.0.0", source-map-js@^1.0.2:
   version "1.2.1"
   resolved "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz"
   integrity sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==
@@ -3397,7 +3787,7 @@ typescript-eslint@^8.46.0:
     "@typescript-eslint/typescript-estree" "8.59.0"
     "@typescript-eslint/utils" "8.59.0"
 
-typescript@^5, typescript@>=3.3.1, typescript@>=4.8.4, "typescript@>=4.8.4 <6.1.0":
+typescript@^5:
   version "5.9.3"
   resolved "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz"
   integrity sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==
@@ -3469,7 +3859,7 @@ use-intl@^4.9.1:
     icu-minify "^4.9.1"
     intl-messageformat "^11.1.0"
 
-use-sync-external-store@^1.6.0, use-sync-external-store@>=1.2.0:
+use-sync-external-store@^1.6.0:
   version "1.6.0"
   resolved "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz"
   integrity sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==


### PR DESCRIPTION
## Vista de partidos jugados con marcador, predicciones y aciertos
Este PR resuelve el issue #26 agregando la vista de resultados de partidos finalizados y predicciones de los usuarios.

##  Cambios
- **Vista de Resultados**: Pestaña de resultados dentro de los grupos y página general con el listado de partidos finalizados (ordenados por fecha más reciente).
- **Visualización de Badges**: Se muestran las predicciones del usuario, el estado del acierto (👑 para exacto, ⚽ para parcial, ❌ para incorrecto) y los puntos obtenidos de forma directa.
- **Correcciones**:
  - Solución al error de carga de next-intl (`results.loading` por claves duplicadas en los archivos JSON de traducciones).
  - Unificación del import de `useAuthStore` para evitar duplicación de estados en el empaquetado del navegador.
  - Carga dinámica del mock de predicciones según el usuario con la sesión activa.

