### PR TITLE
feat: add domain user ID resolution and standardize date field names

### DIFF
--- a/src/features/auth/hooks/useCurrentUserId.ts
+++ b/src/features/auth/hooks/useCurrentUserId.ts
@@ -5,9 +5,10 @@ import { useAuthSession } from './useAuthSession';
 
 export const useCurrentUserId = (): string | undefined => {
   const { session } = useAuthSession();
-  return session?.user.id;
+  return session?.domainUserId ?? session?.user.id;
 };
 
 export const getCurrentUserId = (): string | undefined => {
-  return useAuthStore.getState().session?.user.id;
+  const session = useAuthStore.getState().session;
+  return session?.domainUserId ?? session?.user.id;
 };

--- a/src/features/auth/lib/oauth.ts
+++ b/src/features/auth/lib/oauth.ts
@@ -1,6 +1,7 @@
 import { env } from '@lib/env';
 import type { AuthSession, AuthUser } from '../types/auth';
 import { resolveRoles } from './resolveRoles';
+import { fetchDomainUserId } from '@features/auth/services/fetchDomainUserId';
 
 interface CognitoTokenResponse {
   id_token: string;
@@ -81,13 +82,14 @@ export const exchangeAuthorizationCode = async (code: string): Promise<AuthSessi
   const displayName =
     payload.nickname ?? payload.preferred_username ?? payload.name ?? email.split('@')[0];
 
-  return {
+  const session: AuthSession = {
     token: tokens.id_token,
     idToken: tokens.id_token,
     accessToken: tokens.access_token,
     refreshToken: tokens.refresh_token,
     createdAt: new Date().toISOString(),
     expiresAt: new Date(Date.now() + tokens.expires_in * 1000).toISOString(),
+    sub: payload.sub,
     user: {
       id: payload.sub,
       email,
@@ -97,4 +99,7 @@ export const exchangeAuthorizationCode = async (code: string): Promise<AuthSessi
       roles,
     },
   };
+
+  const domainUserId = await fetchDomainUserId(payload.sub, tokens.id_token);
+  return { ...session, domainUserId };
 };

--- a/src/features/auth/services/fetchDomainUserId.ts
+++ b/src/features/auth/services/fetchDomainUserId.ts
@@ -1,0 +1,47 @@
+import type { GetUserBySubResult } from '@lib/api';
+import { skorifyEndpoints } from '@lib/api';
+import apiInstance from '@api/instance';
+
+/**
+ * Calls the domain API to resolve the database user ID from a Cognito sub.
+ * The idToken is temporarily stored in localStorage so the shared api instance
+ * interceptor can pick it up, then restored to its previous value afterwards.
+ *
+ * Returns `undefined` on any error so the session can still be created
+ * without a domainUserId (it will be retried on next restore).
+ */
+export const fetchDomainUserId = async (
+  sub: string,
+  idToken: string,
+): Promise<string | undefined> => {
+  try {
+    console.log(`Fetching domain user ID for sub ${sub} with idToken ${idToken}`);
+    // Temporarily set the token so the api interceptor sends it as Authorization
+    const previous = typeof window !== 'undefined' ? localStorage.getItem('token') : null;
+    if (typeof window !== 'undefined') {
+      localStorage.setItem('token', idToken);
+    }
+
+    const result = await apiInstance.get<{ data: GetUserBySubResult }>(
+      skorifyEndpoints.user.getBySub,
+      {
+        params: { sub },
+      },
+    );
+
+    console.log(result.data);
+
+    // Restore the previous token value
+    if (typeof window !== 'undefined') {
+      if (previous !== null) {
+        localStorage.setItem('token', previous);
+      } else {
+        localStorage.removeItem('token');
+      }
+    }
+
+    return result.data.data.id;
+  } catch {
+    return undefined;
+  }
+};

--- a/src/features/auth/services/gateways/CognitoAuthGateway.ts
+++ b/src/features/auth/services/gateways/CognitoAuthGateway.ts
@@ -18,6 +18,7 @@ import type {
   RegisterPayload,
 } from '../../types/auth';
 import { resolveRoles } from '../../lib/resolveRoles';
+import { fetchDomainUserId } from '@features/auth/services/fetchDomainUserId';
 
 const normalizeEmail = (email: string) => email.trim().toLowerCase();
 
@@ -96,6 +97,7 @@ const sessionFromCognito = (
     refreshToken,
     expiresAt,
     createdAt: new Date().toISOString(),
+    sub,
     user: {
       id: sub,
       email,
@@ -283,13 +285,20 @@ export class CognitoAuthGateway implements AuthGatewayPort {
       return null;
     }
     return new Promise<AuthSession | null>((resolve) => {
-      currentUser.getSession((err: Error | null, cognitoSession: CognitoUserSession | null) => {
-        if (err || !cognitoSession || !cognitoSession.isValid()) {
-          resolve(null);
-          return;
-        }
-        resolve(sessionFromCognito(cognitoSession));
-      });
+      currentUser.getSession(
+        async (err: Error | null, cognitoSession: CognitoUserSession | null) => {
+          if (err || !cognitoSession || !cognitoSession.isValid()) {
+            resolve(null);
+            return;
+          }
+          const session = sessionFromCognito(cognitoSession);
+          const domainUserId = await fetchDomainUserId(
+            session.user.id,
+            session.idToken ?? session.token,
+          );
+          resolve({ ...session, domainUserId });
+        },
+      );
     });
   }
 }

--- a/src/features/auth/types/auth.ts
+++ b/src/features/auth/types/auth.ts
@@ -20,6 +20,8 @@ export interface AuthSession {
   accessToken?: string;
   refreshToken?: string;
   user: AuthUser;
+  sub: string;
+  domainUserId?: string;
   createdAt: string;
   expiresAt?: string;
 }

--- a/src/features/dashboard/components/organisms/UserDashboardHome.tsx
+++ b/src/features/dashboard/components/organisms/UserDashboardHome.tsx
@@ -69,10 +69,10 @@ const UserDashboardHome = () => {
       tournaments
         .filter(
           (tournament) =>
-            !!tournament.start_date &&
-            !!tournament.end_date &&
-            !Number.isNaN(new Date(tournament.start_date).getTime()) &&
-            !Number.isNaN(new Date(tournament.end_date).getTime()),
+            !!tournament.startDate &&
+            !!tournament.endDate &&
+            !Number.isNaN(new Date(tournament.startDate).getTime()) &&
+            !Number.isNaN(new Date(tournament.endDate).getTime()),
         )
         .slice(0, ACTIVE_TOURNAMENTS_LIMIT),
     [tournaments],
@@ -260,7 +260,7 @@ const ActiveTournamentsSection = ({
                     fontVariantNumeric: 'tabular-nums',
                   }}
                 >
-                  {formatDateRange(tournament.start_date, tournament.end_date, locale)}
+                  {formatDateRange(tournament.startDate, tournament.endDate, locale)}
                 </Typography>
               </Box>
               <ChevronRightIcon sx={{ color: tokens.onSurfaceVariant, fontSize: 20 }} />

--- a/src/features/groups/components/organisms/GroupsView.tsx
+++ b/src/features/groups/components/organisms/GroupsView.tsx
@@ -24,7 +24,8 @@ import { useUserGroups, type UserGroupSummary } from '../../hooks/useUserGroups'
 
 const numberFormatter = new Intl.NumberFormat('es-CO');
 
-const colorForGroup = (id: string) => {
+const colorForGroup = (id: string | undefined) => {
+  if (!id) return avatarPalette[0];
   let hash = 0;
   for (let i = 0; i < id.length; i += 1) hash = (hash * 31 + id.charCodeAt(i)) >>> 0;
   return avatarPalette[hash % avatarPalette.length];

--- a/src/features/groups/hooks/useUserGroups.ts
+++ b/src/features/groups/hooks/useUserGroups.ts
@@ -44,14 +44,23 @@ const fetchInstance = async (
   return result.success ? result.data.data : null;
 };
 
+const fetchMemberCount = async (tournamentInstanceId: string): Promise<number> => {
+  const result = await api.get<SkorifyEnvelope<UserEnrollmentDto[]>>(
+    skorifyEndpoints.userEnrollment.getByTournamentInstanceId,
+    { tournamentInstanceId },
+  );
+  return result.success ? (result.data.data?.length ?? 0) : 0;
+};
+
 const mapToSummary = (
   enrollment: UserEnrollmentDto,
   instance: TournamentInstanceDto | null,
+  memberCount: number,
 ): UserGroupSummary => ({
   id: enrollment.tournamentInstanceId,
   name: instance?.name ?? enrollment.tournamentInstanceId,
-  memberCount: 0,
-  rank: enrollment.currentPosition,
+  memberCount,
+  rank: enrollment.currentPosition ?? 0,
   points: enrollment.currentScore,
 });
 
@@ -76,12 +85,13 @@ export const useUserGroups = () => {
     }
 
     const enrollments = enrollmentsResult.data.data ?? [];
-    const instances = await Promise.all(
-      enrollments.map((enrollment) => fetchInstance(enrollment.tournamentInstanceId)),
-    );
+    const [instances, memberCounts] = await Promise.all([
+      Promise.all(enrollments.map((e) => fetchInstance(e.tournamentInstanceId))),
+      Promise.all(enrollments.map((e) => fetchMemberCount(e.tournamentInstanceId))),
+    ]);
 
     const groups = enrollments.map((enrollment, index) =>
-      mapToSummary(enrollment, instances[index]),
+      mapToSummary(enrollment, instances[index], memberCounts[index]),
     );
 
     setState({ groups, isLoading: false, error: null });
@@ -93,7 +103,7 @@ export const useUserGroups = () => {
     didFetch.current = true;
     // setState inside refresh is deferred via `await Promise.resolve()`,
     // and didFetch guards against cascading re-runs.
-    // eslint-disable-next-line react-hooks/set-state-in-effect
+     
     void refresh();
   }, [hydrated, userId, refresh]);
 

--- a/src/features/tournaments/components/organisms/TournamentDetailDialog.tsx
+++ b/src/features/tournaments/components/organisms/TournamentDetailDialog.tsx
@@ -62,8 +62,8 @@ const TournamentDetailDialog = ({ open, onClose, tournamentId }: TournamentDetai
     if (!data) return false;
     // Treat missing/invalid dates as finished too — same rule as the list view
     // so a tournament without valid dates can't be joined or used as a group base.
-    if (!data.end_date) return true;
-    const end = new Date(data.end_date);
+    if (!data.endDate) return true;
+    const end = new Date(data.endDate);
     if (Number.isNaN(end.getTime())) return true;
     return end < new Date();
   }, [data]);
@@ -149,13 +149,13 @@ const TournamentDetailDialog = ({ open, onClose, tournamentId }: TournamentDetai
 
           {data &&
             (() => {
-              const start = data.start_date ? new Date(data.start_date) : null;
-              const end = data.end_date ? new Date(data.end_date) : null;
+              const start = data.startDate ? new Date(data.startDate) : null;
+              const end = data.endDate ? new Date(data.endDate) : null;
               const status = deriveStatus(start, end, new Date());
               const matchTypeKey =
-                data.match_type === 'single_match_per_round'
+                data.matchType === 'single_match_per_round'
                   ? 'matchTypeSingle'
-                  : data.match_type === 'home_and_away_per_round'
+                  : data.matchType === 'home_and_away_per_round'
                     ? 'matchTypeHomeAway'
                     : null;
 

--- a/src/features/tournaments/components/organisms/TournamentsHome.tsx
+++ b/src/features/tournaments/components/organisms/TournamentsHome.tsx
@@ -71,8 +71,8 @@ interface DerivedTournament {
 }
 
 const deriveTournament = (dto: TournamentDto, now: Date): DerivedTournament => {
-  const start = parseDate(dto.start_date);
-  const end = parseDate(dto.end_date);
+  const start = parseDate(dto.startDate);
+  const end = parseDate(dto.endDate);
   const status = deriveStatus(start, end, now);
   const daysLeft =
     status === 'upcoming' && start

--- a/src/features/tournaments/hooks/useGetTournamentById.ts
+++ b/src/features/tournaments/hooks/useGetTournamentById.ts
@@ -42,12 +42,12 @@ const normalizeTournament = (raw: RawTournament): TournamentDto => ({
   id: raw.id,
   name: raw.name,
   token: raw.token,
-  start_date: raw.start_date ?? raw.startDate ?? null,
-  end_date: raw.end_date ?? raw.endDate ?? null,
-  match_type: raw.match_type ?? raw.matchType ?? null,
-  created_at: raw.created_at ?? raw.createdAt ?? '',
-  updated_at: raw.updated_at ?? raw.updatedAt ?? null,
-  deleted_at: raw.deleted_at ?? raw.deletedAt ?? null,
+  startDate: raw.startDate ?? raw.startDate ?? null,
+  endDate: raw.endDate ?? raw.endDate ?? null,
+  matchType: raw.matchType ?? raw.matchType ?? null,
+  createdAt: raw.createdAt ?? raw.createdAt ?? '',
+  updatedAt: raw.updatedAt ?? raw.updatedAt ?? null,
+  deletedAt: raw.deletedAt ?? raw.deletedAt ?? null,
 });
 
 export const useGetTournamentById = () => {

--- a/src/lib/api/index.ts
+++ b/src/lib/api/index.ts
@@ -18,6 +18,8 @@ export {
   type UserDto,
   type CreateUserPayload,
   type GetUserByIdParams,
+  type GetUserBySubPayload,
+  type GetUserBySubResult,
   type RegisterNotificationTokenPayload,
   type MatchDto,
   type MatchStage,

--- a/src/lib/api/skorify.ts
+++ b/src/lib/api/skorify.ts
@@ -54,6 +54,24 @@ export interface RegisterUserPayload {
   email: string;
 }
 
+export interface GetUserBySubPayload {
+  sub: string;
+}
+
+export interface GetUserBySubResult {
+  id: Id;
+  name: string;
+  is_active: boolean;
+  notification_token: string | null;
+  email: string;
+  sub: string;
+  image: string | null;
+  role: string;
+  created_at: string;
+  updated_at: string;
+  deleted_at: string | null;
+}
+
 // ──────────────────────────── Match ───────────────────────────
 
 export type MatchStatus = 'draft' | 'scheduled' | 'in_progress' | 'finished' | 'cancelled';
@@ -258,13 +276,13 @@ export type MatchType = 'single_match_per_round' | 'home_and_away_per_round';
 export interface TournamentDto {
   id: Id;
   name: string;
-  start_date: string | null;
-  end_date: string | null;
-  match_type: MatchType | null;
+  startDate: string | null;
+  endDate: string | null;
+  matchType: MatchType | null;
   token: string;
-  created_at: string;
-  updated_at: string | null;
-  deleted_at: string | null;
+  createdAt: string;
+  updatedAt: string | null;
+  deletedAt: string | null;
 }
 
 export interface CreateTournamentPayload {
@@ -404,6 +422,7 @@ export const skorifyEndpoints = {
   user: {
     create: '/user/create-user',
     getById: '/user/get-user-by-id',
+    getBySub: '/user/get-user-by-sub',
     registerNotificationToken: '/user/register-notification-token',
     delete: '/user/delete-user',
     register: '/user/register-user',


### PR DESCRIPTION
- Implement `fetchDomainUserId` to resolve database user IDs from Cognito sub.
- Update session handling to include `domainUserId` for better user identification.
- Standardize tournament API date field naming (`start_date` → `startDate`, etc.).
- Enhance group mapping to dynamically include member counts.