### PR TITLE
feat: enhance match filtering and fetch team data

### DIFF
--- a/src/features/matches/components/organisms/MatchesHome.tsx
+++ b/src/features/matches/components/organisms/MatchesHome.tsx
@@ -8,6 +8,11 @@ import Stack from '@mui/material/Stack';
 import AddIcon from '@mui/icons-material/Add';
 import AppButton from '@shared/components/atoms/AppButton';
 import { useAuthSession } from '@features/auth/hooks/useAuthSession';
+import { useCurrentUserId } from '@features/auth/hooks/useCurrentUserId';
+import { useGetUserEnrollmentsByUserId } from '@features/groups/hooks/useGetUserEnrollmentsByUserId';
+import { useGetMatchesByTournamentId } from '../../hooks/useGetMatchesByTournamentId';
+import { useGetTournamentById } from '@features/tournaments/hooks/useGetTournamentById';
+import { useGetTeamsByIds } from '@features/teams';
 import { formatKickoff } from '../../utils/formatKickoff';
 import CreateMatchDrawer from './CreateMatchDrawer';
 import MatchCard from '../molecules/MatchCard';
@@ -15,15 +20,23 @@ import MatchesEmptyState from '../molecules/MatchesEmptyState';
 import MatchesHeader from '../molecules/MatchesHeader';
 import PaginatedMatchesGrid from '../molecules/PaginatedMatchesGrid';
 import MatchesToolbar from '../molecules/MatchesToolbar';
-import { useMatchesList } from '../../hooks/useMatchesList';
 import { getWorldCupWeekOptions2026 } from '../../filters/weekOptions';
+import { worldCupWeekToFromToIso, statusFromFilter } from '../../filters/MatchesQuery';
+import type { MatchesFilterKey } from '../molecules/MatchesFilters';
 import {
   PredictionDrawer,
   type PredictionDrawerMatch,
   type PredictionDrawerScore,
 } from '@features/predictions';
 import { getCountryFlagUrl } from '@shared/utils/flag';
-import type { Match } from '../../types';
+import type { Match, MatchStatus } from '../../types';
+import type { MatchDto } from '@lib/api/skorify';
+
+const mapStatus = (status: MatchDto['status']): MatchStatus => {
+  if (status === 'in_progress') return 'live';
+  if (status === 'finished' || status === 'cancelled') return 'finished';
+  return 'upcoming';
+};
 
 const toPredictionDrawerMatch = (match: Match): PredictionDrawerMatch => ({
   id: match.id,
@@ -34,6 +47,10 @@ const toPredictionDrawerMatch = (match: Match): PredictionDrawerMatch => ({
   kickoffAt: match.kickoffAt,
 });
 
+const PAGE_SIZE = 10;
+
+// ── component ──────────────────────────────────────────────────────────────
+
 const MatchesHome = () => {
   const t = useTranslations('matches');
   const tAdmin = useTranslations('matchesAdmin');
@@ -43,35 +60,133 @@ const MatchesHome = () => {
   const searchParams = useSearchParams();
   const pathname = usePathname();
   const router = useRouter();
-  const { query, setStatusFilter, setTeam, setWeek, setPage, loading, items, total, resetFilters } =
-    useMatchesList(10);
-  const [selectedMatchId, setSelectedMatchId] = useState<string | null>(null);
-  // Open the drawer on mount when arriving with `?create=1` (linked from the
-  // admin nav). Reads the param once via lazy init to avoid effect cascades.
-  const [createDrawerOpen, setCreateDrawerOpen] = useState(
-    () => searchParams.get('create') === '1',
-  );
+
+  // ── enrollments → tournamentId ──────────────────────────────────────────
+  const userId = useCurrentUserId();
+  const {
+    getUserEnrollmentsByUserId,
+    data: enrollments,
+    isLoading: enrollmentsLoading,
+  } = useGetUserEnrollmentsByUserId();
 
   useEffect(() => {
-    if (searchParams.get('create') !== '1') return;
-    // Consume the param so reloads/back-nav don't reopen the drawer.
-    router.replace(pathname, { scroll: false });
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
-  const [predictionsById, setPredictionsById] = useState<Record<string, PredictionDrawerScore>>(
+    if (!userId) return;
+    void getUserEnrollmentsByUserId({ userId });
+  }, [userId, getUserEnrollmentsByUserId]);
+
+  const tournamentId = enrollments[0]?.tournamentId;
+
+  // ── backend: tournament name ────────────────────────────────────────────
+  const { getTournamentById, data: tournament } = useGetTournamentById();
+
+  useEffect(() => {
+    if (!tournamentId) return;
+    void getTournamentById({ tournamentId });
+  }, [tournamentId, getTournamentById]);
+
+  // ── backend: matches by tournament ─────────────────────────────────────
+  const { data: backendMatches, isLoading: matchesLoading } = useGetMatchesByTournamentId({
+    tournamentId,
+  });
+
+  // ── backend: team names ─────────────────────────────────────────────────
+  const teamIds = useMemo(() => {
+    const ids = new Set<string>();
+    backendMatches.forEach((dto) => {
+      ids.add(dto.homeTeamId);
+      ids.add(dto.awayTeamId);
+    });
+    return Array.from(ids);
+  }, [backendMatches]);
+
+  const { teams: teamsLookup } = useGetTeamsByIds(teamIds);
+
+  // ── map DTOs → Match ────────────────────────────────────────────────────
+  const allMatches = useMemo<Match[]>(
     () =>
-      items.reduce<Record<string, PredictionDrawerScore>>((acc, match) => {
-        if (match.prediction) {
-          acc[match.id] = { homeGoals: match.prediction.home, awayGoals: match.prediction.away };
-        }
-        return acc;
-      }, {}),
+      [...backendMatches]
+        .sort((a, b) => new Date(a.kickOff).getTime() - new Date(b.kickOff).getTime())
+        .map((dto) => {
+          const home = teamsLookup[dto.homeTeamId];
+          const away = teamsLookup[dto.awayTeamId];
+          return {
+            id: dto.id,
+            tournamentKey: dto.tournamentId,
+            stageKey: dto.stage ?? 'group',
+            status: mapStatus(dto.status),
+            kickoffAt: dto.kickOff,
+            homeTeam: { name: home?.name ?? dto.homeTeamId, code: undefined },
+            awayTeam: { name: away?.name ?? dto.awayTeamId, code: undefined },
+            score:
+              typeof dto.homeScore === 'number' && typeof dto.awayScore === 'number'
+                ? { home: dto.homeScore, away: dto.awayScore }
+                : undefined,
+          };
+        }),
+    [backendMatches, teamsLookup],
   );
 
-  const monthOptions = useMemo(() => getWorldCupWeekOptions2026(locale), [locale]);
+  // ── filter state ────────────────────────────────────────────────────────
+  const [statusFilter, setStatusFilter] = useState<MatchesFilterKey>('filterAll');
+  const [team, setTeam] = useState('');
+  const [week, setWeek] = useState('');
+  const [page, setPage] = useState(1);
+
+  const resetFilters = useCallback(() => {
+    setStatusFilter('filterAll');
+    setTeam('');
+    setWeek('');
+    setPage(1);
+  }, []);
+
+  const handleStatusFilter = useCallback((f: MatchesFilterKey) => {
+    setStatusFilter(f);
+    setPage(1);
+  }, []);
+  const handleTeam = useCallback((v: string) => {
+    setTeam(v);
+    setPage(1);
+  }, []);
+  const handleWeek = useCallback((v: string) => {
+    setWeek(v);
+    setPage(1);
+  }, []);
+
+  // ── client-side filter + paginate ───────────────────────────────────────
+  const filtered = useMemo(() => {
+    const status = statusFromFilter(statusFilter);
+    const { from, to } = worldCupWeekToFromToIso(Number(week));
+    const fromMs = from ? new Date(from).getTime() : undefined;
+    const toMs = to ? new Date(to).getTime() : undefined;
+    const q = team.trim().toLowerCase();
+
+    return allMatches.filter((m) => {
+      if (status && m.status !== status) return false;
+      if (q) {
+        const home = `${m.homeTeam.name} ${m.homeTeam.code ?? ''}`.toLowerCase();
+        const away = `${m.awayTeam.name} ${m.awayTeam.code ?? ''}`.toLowerCase();
+        if (!home.includes(q) && !away.includes(q)) return false;
+      }
+      const k = new Date(m.kickoffAt).getTime();
+      if (fromMs !== undefined && k < fromMs) return false;
+      if (toMs !== undefined && k > toMs) return false;
+      return true;
+    });
+  }, [allMatches, statusFilter, team, week]);
+
+  const total = filtered.length;
+  const pagedItems = useMemo(() => {
+    const start = (page - 1) * PAGE_SIZE;
+    return filtered.slice(start, start + PAGE_SIZE);
+  }, [filtered, page]);
+
+  // ── prediction overlay state ────────────────────────────────────────────
+  const [predictionsById, setPredictionsById] = useState<Record<string, PredictionDrawerScore>>({});
+  const [selectedMatchId, setSelectedMatchId] = useState<string | null>(null);
+
   const displayedItems = useMemo(
     () =>
-      items.map((match) => ({
+      pagedItems.map((match) => ({
         ...match,
         prediction: (() => {
           const saved = predictionsById[match.id];
@@ -80,11 +195,11 @@ const MatchesHome = () => {
           return undefined;
         })(),
       })),
-    [items, predictionsById],
+    [pagedItems, predictionsById],
   );
 
   const selectedMatch = useMemo(
-    () => displayedItems.find((match) => match.id === selectedMatchId) ?? null,
+    () => displayedItems.find((m) => m.id === selectedMatchId) ?? null,
     [displayedItems, selectedMatchId],
   );
 
@@ -94,20 +209,12 @@ const MatchesHome = () => {
   );
 
   const selectedDrawerScore = useMemo<PredictionDrawerScore | undefined>(() => {
-    if (!selectedMatch) return undefined;
-    const prediction = selectedMatch.prediction;
-    if (!prediction) return undefined;
-    return { homeGoals: prediction.home, awayGoals: prediction.away };
+    if (!selectedMatch?.prediction) return undefined;
+    return { homeGoals: selectedMatch.prediction.home, awayGoals: selectedMatch.prediction.away };
   }, [selectedMatch]);
 
-  const handleOpenPrediction = useCallback((match: Match) => {
-    setSelectedMatchId(match.id);
-  }, []);
-
-  const handleCloseDrawer = useCallback(() => {
-    setSelectedMatchId(null);
-  }, []);
-
+  const handleOpenPrediction = useCallback((match: Match) => setSelectedMatchId(match.id), []);
+  const handleCloseDrawer = useCallback(() => setSelectedMatchId(null), []);
   const handleSavePrediction = useCallback(
     async (matchId: string, values: PredictionDrawerScore) => {
       setPredictionsById((prev) => ({ ...prev, [matchId]: values }));
@@ -116,6 +223,21 @@ const MatchesHome = () => {
     [],
   );
 
+  // ── create-match drawer (admin) ─────────────────────────────────────────
+  const [createDrawerOpen, setCreateDrawerOpen] = useState(
+    () => searchParams.get('create') === '1',
+  );
+
+  useEffect(() => {
+    if (searchParams.get('create') !== '1') return;
+    router.replace(pathname, { scroll: false });
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  const monthOptions = useMemo(() => getWorldCupWeekOptions2026(locale), [locale]);
+  const loading = enrollmentsLoading || matchesLoading;
+
+  // ── render ──────────────────────────────────────────────────────────────
   return (
     <Box sx={{ p: { xs: 3, md: 4 }, maxWidth: 1400, mx: 'auto' }}>
       {isAdmin && (
@@ -129,17 +251,17 @@ const MatchesHome = () => {
       <MatchesHeader
         title={t('title')}
         subtitle={`${total} ${t('matchesCount')}`}
-        activeFilter={query.statusFilter}
-        onFilterChange={setStatusFilter}
+        activeFilter={statusFilter}
+        onFilterChange={handleStatusFilter}
         filterLabelFor={(key) => t(key)}
       />
 
       <MatchesToolbar
-        teamValue={query.team}
-        onTeamChange={setTeam}
+        teamValue={team}
+        onTeamChange={handleTeam}
         teamPlaceholder={t('teamFilterPlaceholder')}
-        weekValue={query.week}
-        onMonthChange={setWeek}
+        weekValue={week}
+        onMonthChange={handleWeek}
         monthLabel={t('date')}
         monthAllLabel={t('dateAll')}
         monthOptions={monthOptions}
@@ -154,17 +276,17 @@ const MatchesHome = () => {
       ) : (
         <PaginatedMatchesGrid
           items={displayedItems}
-          page={query.page}
+          page={page}
           totalItems={total}
-          pageSize={query.pageSize}
+          pageSize={PAGE_SIZE}
           onPageChange={setPage}
           getKey={(m) => m.id}
           gridSize={{ xs: 12, sm: 12, md: 6, lg: 6 }}
           renderItem={(m) => (
             <MatchCard
               match={m}
-              tournamentLabel={t(m.tournamentKey)}
-              stageLabel={t(m.stageKey)}
+              tournamentLabel={tournament?.name ?? m.tournamentKey}
+              stageLabel={t(m.stageKey + 'Stage')}
               statusLabel={t(m.status)}
               kickoffLabel={formatKickoff(m.kickoffAt, locale)}
               vsLabel={t('vs')}

--- a/src/features/matches/hooks/useMatchesList.ts
+++ b/src/features/matches/hooks/useMatchesList.ts
@@ -24,10 +24,16 @@ type UseMatchesListState = {
   total: number;
 };
 
+interface UseMatchesListOptions {
+  tournamentId?: string;
+}
+
 export const useMatchesList = (
   initialPageSize = 10,
   initialFilter: MatchesFilterKey = 'filterAll',
+  options: UseMatchesListOptions = {},
 ): UseMatchesListState => {
+  const { tournamentId } = options;
   const [query, setQuery] = useState<MatchesQuery>({
     statusFilter: initialFilter,
     team: '',
@@ -46,6 +52,7 @@ export const useMatchesList = (
     const status = statusFromFilter(query.statusFilter);
     const { from, to } = worldCupWeekToFromToIso(Number(query.week));
     return {
+      tournamentId,
       page: query.page,
       pageSize: query.pageSize,
       status,
@@ -53,7 +60,7 @@ export const useMatchesList = (
       from,
       to,
     };
-  }, [query]);
+  }, [query, tournamentId]);
 
   useEffect(() => {
     let mounted = true;

--- a/src/features/predictions/components/organisms/PredictionsView.tsx
+++ b/src/features/predictions/components/organisms/PredictionsView.tsx
@@ -25,8 +25,15 @@ import { getWorldCupWeekOptions2026 } from '@shared/components/organisms/MatchLi
 import { useCurrentUserId } from '@features/auth/hooks/useCurrentUserId';
 import { useGetUserEnrollmentsByUserId } from '@features/groups/hooks/useGetUserEnrollmentsByUserId';
 import { useGetMatchesByTournamentId } from '@features/matches/hooks/useGetMatchesByTournamentId';
-import { useTeamsLookup } from '@features/teams';
-import type { MatchDto, PredictionDto } from '@lib/api/skorify';
+import { useGetTeamsByIds } from '@features/teams';
+import { api } from '@lib/api';
+import type {
+  MatchDto,
+  PredictionDto,
+  SkorifyEnvelope,
+  TournamentInstanceDto,
+} from '@lib/api/skorify';
+import { skorifyEndpoints } from '@lib/api/skorify';
 import PredictionsToolbar, { type PredictionsToolbarValues } from '../molecules/PredictionsToolbar';
 import MatchesPanel, { type MatchesPanelSavedPrediction } from './MatchesPanel';
 import PredictionDrawer, { type PredictionDrawerMatch } from './PredictionDrawer';
@@ -80,6 +87,27 @@ const PredictionsView = () => {
     void getUserEnrollmentsByUserId({ userId });
   }, [userId, getUserEnrollmentsByUserId]);
 
+  // ── fetch instance names for the selector ──────────────────────────────
+  const [instancesById, setInstancesById] = useState<Record<string, TournamentInstanceDto>>({});
+
+  useEffect(() => {
+    if (enrollments.length === 0) return;
+    void Promise.all(
+      enrollments.map((e) =>
+        api.get<SkorifyEnvelope<TournamentInstanceDto>>(
+          skorifyEndpoints.tournamentInstance.getById,
+          { tournamentInstanceId: e.tournamentInstanceId },
+        ),
+      ),
+    ).then((results) => {
+      const lookup: Record<string, TournamentInstanceDto> = {};
+      results.forEach((res) => {
+        if (res.success) lookup[res.data.data.id] = res.data.data;
+      });
+      setInstancesById(lookup);
+    });
+  }, [enrollments]);
+
   const activeEnrollment = useMemo(
     () => enrollments.find((e) => e.tournamentInstanceId === tournamentInstanceId) ?? null,
     [enrollments, tournamentInstanceId],
@@ -113,7 +141,7 @@ const PredictionsView = () => {
     });
     return Array.from(ids);
   }, [backendMatches]);
-  const { teams: teamsLookup } = useTeamsLookup(teamIds);
+  const { teams: teamsLookup } = useGetTeamsByIds(teamIds);
 
   const { savedPredictions, predictionIdByMatch } = useMemo(() => {
     const saved: Record<string, MatchesPanelSavedPrediction> = {};
@@ -129,19 +157,21 @@ const PredictionsView = () => {
   }, [userPredictions]);
 
   const matches = useMemo<PredictionMatch[]>(() => {
-    return backendMatches.map((dto: MatchDto) => {
-      const home = teamsLookup[dto.homeTeamId];
-      const away = teamsLookup[dto.awayTeamId];
-      return {
-        id: dto.id,
-        homeTeam: home?.name ?? dto.homeTeamId,
-        awayTeam: away?.name ?? dto.awayTeamId,
-        homeTeamFlag: home?.shieldUrl ?? '',
-        awayTeamFlag: away?.shieldUrl ?? '',
-        date: dto.kickOff,
-        isUserPredicted: dto.id in savedPredictions,
-      };
-    });
+    return [...backendMatches]
+      .sort((a, b) => new Date(a.kickOff).getTime() - new Date(b.kickOff).getTime())
+      .map((dto: MatchDto) => {
+        const home = teamsLookup[dto.homeTeamId];
+        const away = teamsLookup[dto.awayTeamId];
+        return {
+          id: dto.id,
+          homeTeam: home?.name ?? dto.homeTeamId,
+          awayTeam: away?.name ?? dto.awayTeamId,
+          homeTeamFlag: home?.shieldUrl ?? '',
+          awayTeamFlag: away?.shieldUrl ?? '',
+          date: dto.kickOff,
+          isUserPredicted: dto.id in savedPredictions,
+        };
+      });
   }, [backendMatches, teamsLookup, savedPredictions]);
 
   const savedMessages = useMemo(() => t.raw('savedMessages') as string[], [t]);
@@ -387,7 +417,8 @@ const PredictionsView = () => {
           </MenuItem>
           {enrollments.map((enrollment) => (
             <MenuItem key={enrollment.id} value={enrollment.tournamentInstanceId}>
-              {enrollment.tournamentInstanceId}
+              {instancesById[enrollment.tournamentInstanceId]?.name ??
+                enrollment.tournamentInstanceId}
             </MenuItem>
           ))}
         </Select>

--- a/src/features/teams/hooks/useGetTeamsByIds.ts
+++ b/src/features/teams/hooks/useGetTeamsByIds.ts
@@ -1,0 +1,71 @@
+'use client';
+
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { api } from '@lib/api';
+import {
+  skorifyEndpoints,
+  type GetTeamByIdsParams,
+  type SkorifyEnvelope,
+  type TeamDto,
+} from '@lib/api/skorify';
+import type { ApiError } from '@lib/api/types';
+
+export type TeamsByIdsLookup = Record<string, TeamDto | undefined>;
+
+interface UseGetTeamsByIdsState {
+  isLoading: boolean;
+  error: ApiError | null;
+  teams: TeamsByIdsLookup;
+}
+
+const initialState: UseGetTeamsByIdsState = {
+  isLoading: false,
+  error: null,
+  teams: {},
+};
+
+export const useGetTeamsByIds = (teamIds: string[]) => {
+  const [state, setState] = useState<UseGetTeamsByIdsState>(initialState);
+  const lastKeyRef = useRef<string>('');
+
+  const fetchTeams = useCallback(async (params: GetTeamByIdsParams): Promise<TeamsByIdsLookup> => {
+    if (params.teamIds.length === 0) return {};
+
+    setState((prev) => ({ ...prev, isLoading: true, error: null }));
+
+    const qs = params.teamIds.map((id) => `teamIds=${encodeURIComponent(id)}`).join('&');
+    const result = await api.get<SkorifyEnvelope<TeamDto[]>>(
+      `${skorifyEndpoints.team.getByIds}?${qs}`,
+    );
+
+    if (result.success) {
+      const lookup: TeamsByIdsLookup = {};
+      (result.data.data ?? []).forEach((team) => {
+        lookup[team.id] = team;
+      });
+      setState({ isLoading: false, error: null, teams: lookup });
+      return lookup;
+    }
+
+    setState((prev) => ({ ...prev, isLoading: false, error: result.error }));
+    return {};
+  }, []);
+
+  // Re-fetch whenever the set of IDs changes.
+  const key = teamIds.slice().sort().join('|');
+  useEffect(() => {
+    if (!key || key === lastKeyRef.current) return;
+    lastKeyRef.current = key;
+    void fetchTeams({ teamIds });
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [key]);
+
+  const reset = useCallback(() => {
+    lastKeyRef.current = '';
+    setState(initialState);
+  }, []);
+
+  return { fetchTeams, reset, ...state };
+};
+
+export default useGetTeamsByIds;

--- a/src/features/teams/index.ts
+++ b/src/features/teams/index.ts
@@ -1,2 +1,4 @@
 export { useTeamsLookup } from './hooks/useTeamsLookup';
 export type { TeamsLookup } from './hooks/useTeamsLookup';
+export { useGetTeamsByIds } from './hooks/useGetTeamsByIds';
+export type { TeamsByIdsLookup } from './hooks/useGetTeamsByIds';

--- a/src/i18n/messages/en.json
+++ b/src/i18n/messages/en.json
@@ -293,6 +293,7 @@
     "finished": "Finished",
     "worldcup": "FIFA World Cup 2026",
     "groupStage": "Group stage",
+    "finalStage": "Final stage",
     "roundOf16": "Round of 16",
     "resultForm": {
       "title": "Load Match Result",

--- a/src/i18n/messages/es.json
+++ b/src/i18n/messages/es.json
@@ -298,6 +298,7 @@
     "finished": "Finalizados",
     "worldcup": "Copa del Mundo FIFA 2026",
     "groupStage": "Fase de grupos",
+    "finalsStage": "Fase final",
     "roundOf16": "Octavos de final",
     "resultForm": {
       "title": "Cargar resultado del partido",


### PR DESCRIPTION
- Add dynamic match filtering on team, week, and status.
- Fetch team data by IDs and integrate team names in matches.
- Extend translations for new stages (`finalStage`/`fase final`).