### PR TITLE
feat(matches): add "pending score" badge support and enhance result r…

### DIFF
--- a/src/app/(dashboard)/results/page.tsx
+++ b/src/app/(dashboard)/results/page.tsx
@@ -66,11 +66,15 @@ export default function ResultsPage() {
 
   // Backend verdict per match (the same values that feed the ranking).
   const verdictByMatch = useMemo(() => {
-    const map: Record<string, { earnedPoints: number; hasExactResult: boolean }> = {};
+    const map: Record<
+      string,
+      { earnedPoints: number; hasExactResult: boolean; isCalculated?: boolean }
+    > = {};
     (userPredictions ?? []).forEach((prediction) => {
       map[prediction.matchId] = {
         earnedPoints: prediction.earnedPoints,
         hasExactResult: prediction.hasExactResult,
+        isCalculated: prediction.isCalculated,
       };
     });
     return map;
@@ -147,6 +151,7 @@ export default function ResultsPage() {
               noPredictionLabel={t('noPrediction')}
               earnedPoints={verdictByMatch[match.id]?.earnedPoints}
               hasExactResult={verdictByMatch[match.id]?.hasExactResult}
+              isCalculated={verdictByMatch[match.id]?.isCalculated}
             />
           ))}
         </Box>

--- a/src/features/groups/components/organisms/GroupDetail.tsx
+++ b/src/features/groups/components/organisms/GroupDetail.tsx
@@ -102,11 +102,15 @@ const GroupDetail = ({ groupId }: GroupDetailProps) => {
 
   // Backend verdict per match (the same values that feed the ranking).
   const verdictByMatch = useMemo(() => {
-    const map: Record<string, { earnedPoints: number; hasExactResult: boolean }> = {};
+    const map: Record<
+      string,
+      { earnedPoints: number; hasExactResult: boolean; isCalculated?: boolean }
+    > = {};
     (userPredictions ?? []).forEach((prediction) => {
       map[prediction.matchId] = {
         earnedPoints: prediction.earnedPoints,
         hasExactResult: prediction.hasExactResult,
+        isCalculated: prediction.isCalculated,
       };
     });
     return map;
@@ -372,6 +376,7 @@ const GroupDetail = ({ groupId }: GroupDetailProps) => {
                         })}
                         earnedPoints={verdictByMatch[match.id]?.earnedPoints}
                         hasExactResult={verdictByMatch[match.id]?.hasExactResult}
+                        isCalculated={verdictByMatch[match.id]?.isCalculated}
                       />
                     ))}
                   </Box>

--- a/src/features/matches/components/molecules/FinishedMatchCard.tsx
+++ b/src/features/matches/components/molecules/FinishedMatchCard.tsx
@@ -13,6 +13,7 @@ import {
   calculatePredictionPoints,
   PredictionResult,
 } from '../../utils/predictionEvaluator';
+import { useTranslations } from 'next-intl';
 
 type Props = {
   match: Match;
@@ -30,6 +31,13 @@ type Props = {
   /** Backend flag for an exact-score hit. Used together with `earnedPoints` to
    *  derive the result label so it stays consistent with the ranking. */
   hasExactResult?: boolean;
+  /**
+   * Whether the admin has already run score calculation for this prediction.
+   * - `true`  → show the result/points badges as usual.
+   * - `false` → the prediction exists but scoring is pending; show a "pending" badge.
+   * - `undefined` → legacy behaviour, show result badges regardless.
+   */
+  isCalculated?: boolean;
 };
 
 const FinishedMatchCard = ({
@@ -43,7 +51,10 @@ const FinishedMatchCard = ({
   noPredictionLabel,
   earnedPoints,
   hasExactResult,
+  isCalculated,
 }: Props) => {
+  const tPredictions = useTranslations('predictions');
+
   // Prefer the backend's verdict (exact / earned points) so the label matches
   // the ranking; only fall back to the client-side evaluation when we don't
   // have the backend data for this prediction.
@@ -86,6 +97,8 @@ const FinishedMatchCard = ({
     (match.score && match.prediction
       ? calculatePredictionPoints(match.score, match.prediction).totalPoints
       : 0);
+
+  const scoreIsPending = isCalculated === false && Boolean(match.prediction);
 
   return (
     <Box
@@ -246,37 +259,16 @@ const FinishedMatchCard = ({
             </Box>
           ) : null}
 
-          {/* 2. Badge de Resultado: [X INCORRECTO] */}
-          <Box
-            sx={{
-              display: 'flex',
-              alignItems: 'center',
-              gap: 0.75,
-              bgcolor: `${resultColor}12`,
-              color: resultColor,
-              border: `1px solid ${resultColor}40`,
-              borderRadius: '6px',
-              px: 1.5,
-              py: 0.75,
-              fontSize: '0.6875rem',
-              fontWeight: 800,
-              textTransform: 'uppercase',
-              letterSpacing: '0.08em',
-            }}
-          >
-            <span>{resultIcon}</span>
-            {resultLabel}
-          </Box>
-
-          {/* 3. Badge de Puntaje Ganado: [+2 PTS] */}
-          {match.prediction ? (
+          {/* 2 & 3. Pending badge OR result + points badges */}
+          {scoreIsPending ? (
+            /* ⏳ Score pending evaluation */
             <Box
               sx={{
-                display: 'flex',
+                display: 'inline-flex',
                 alignItems: 'center',
                 gap: 0.75,
-                bgcolor: `${totalPoints > 0 ? tokens.primary : tokens.onSurfaceVariant}12`,
-                border: `1px solid ${totalPoints > 0 ? tokens.primary : tokens.onSurfaceVariant}33`,
+                bgcolor: `${tokens.tertiary}12`,
+                border: `1px solid ${tokens.tertiary}40`,
                 borderRadius: '6px',
                 px: 1.5,
                 py: 0.75,
@@ -284,31 +276,78 @@ const FinishedMatchCard = ({
                 fontWeight: 800,
                 textTransform: 'uppercase',
                 letterSpacing: '0.08em',
-                color: totalPoints > 0 ? tokens.primary : tokens.onSurfaceVariant,
+                color: tokens.tertiary,
               }}
             >
-              {totalPoints > 0 ? `+${totalPoints}` : '0'} {totalPoints === 1 ? 'pt' : 'pts'}
+              ⏳ {tPredictions('pendingScore')}
             </Box>
           ) : (
-            <Box
-              sx={{
-                display: 'flex',
-                alignItems: 'center',
-                gap: 0.75,
-                bgcolor: `${tokens.onSurfaceVariant}12`,
-                border: `1px solid ${tokens.onSurfaceVariant}33`,
-                borderRadius: '6px',
-                px: 1.5,
-                py: 0.75,
-                fontSize: '0.6875rem',
-                fontWeight: 800,
-                textTransform: 'uppercase',
-                letterSpacing: '0.08em',
-                color: tokens.onSurfaceVariant,
-              }}
-            >
-              0 pts
-            </Box>
+            <>
+              {/* 2. Badge de Resultado: [X INCORRECTO] */}
+              <Box
+                sx={{
+                  display: 'flex',
+                  alignItems: 'center',
+                  gap: 0.75,
+                  bgcolor: `${resultColor}12`,
+                  color: resultColor,
+                  border: `1px solid ${resultColor}40`,
+                  borderRadius: '6px',
+                  px: 1.5,
+                  py: 0.75,
+                  fontSize: '0.6875rem',
+                  fontWeight: 800,
+                  textTransform: 'uppercase',
+                  letterSpacing: '0.08em',
+                }}
+              >
+                <span>{resultIcon}</span>
+                {resultLabel}
+              </Box>
+
+              {/* 3. Badge de Puntaje Ganado: [+2 PTS] */}
+              {match.prediction ? (
+                <Box
+                  sx={{
+                    display: 'flex',
+                    alignItems: 'center',
+                    gap: 0.75,
+                    bgcolor: `${totalPoints > 0 ? tokens.primary : tokens.onSurfaceVariant}12`,
+                    border: `1px solid ${totalPoints > 0 ? tokens.primary : tokens.onSurfaceVariant}33`,
+                    borderRadius: '6px',
+                    px: 1.5,
+                    py: 0.75,
+                    fontSize: '0.6875rem',
+                    fontWeight: 800,
+                    textTransform: 'uppercase',
+                    letterSpacing: '0.08em',
+                    color: totalPoints > 0 ? tokens.primary : tokens.onSurfaceVariant,
+                  }}
+                >
+                  {totalPoints > 0 ? `+${totalPoints}` : '0'} {totalPoints === 1 ? 'pt' : 'pts'}
+                </Box>
+              ) : (
+                <Box
+                  sx={{
+                    display: 'flex',
+                    alignItems: 'center',
+                    gap: 0.75,
+                    bgcolor: `${tokens.onSurfaceVariant}12`,
+                    border: `1px solid ${tokens.onSurfaceVariant}33`,
+                    borderRadius: '6px',
+                    px: 1.5,
+                    py: 0.75,
+                    fontSize: '0.6875rem',
+                    fontWeight: 800,
+                    textTransform: 'uppercase',
+                    letterSpacing: '0.08em',
+                    color: tokens.onSurfaceVariant,
+                  }}
+                >
+                  0 pts
+                </Box>
+              )}
+            </>
           )}
         </Box>
       </Box>

--- a/src/i18n/messages/en.json
+++ b/src/i18n/messages/en.json
@@ -280,7 +280,11 @@
       "min": "Cannot be negative",
       "max": "Max 99",
       "integerOnly": "Whole numbers only"
-    }
+    },
+    "pendingScore": "Score pending",
+    "resultExact": "Exact score",
+    "resultPartial": "Partial match",
+    "resultWrong": "Wrong"
   },
   "matchesAdmin": {
     "title": "Create Match",

--- a/src/i18n/messages/es.json
+++ b/src/i18n/messages/es.json
@@ -280,7 +280,11 @@
       "min": "No puede ser negativo",
       "max": "Máximo 99",
       "integerOnly": "Solo números enteros"
-    }
+    },
+    "pendingScore": "Puntaje pendiente",
+    "resultExact": "Marcador exacto",
+    "resultPartial": "Acierto parcial",
+    "resultWrong": "Incorrecto"
   },
   "matchesAdmin": {
     "title": "Crear Partido",

--- a/src/lib/api/skorify.ts
+++ b/src/lib/api/skorify.ts
@@ -164,6 +164,7 @@ export interface PredictionDto {
   score: number;
   earnedPoints: number;
   hasExactResult: boolean;
+  isCalculated?: boolean;
   createdAt: string;
   updatedAt?: string;
   deletedAt?: string;


### PR DESCRIPTION
- Introduced `isCalculated` prop to distinguish between pending and evaluated predictions.
- Updated `FinishedMatchCard` component for conditional badge rendering: pending, result, and points.
- Added translation keys for "pending score" and result labels (exact, partial, wrong) in `i18n`.
- Adjusted API and hooks to pass `isCalculated` data to components.