### PR TITLE
feat(auth): update token usage to access_token 

### DIFF
--- a/src/features/auth/lib/oauth.ts
+++ b/src/features/auth/lib/oauth.ts
@@ -61,7 +61,7 @@ const buildSessionFromTokens = (
   tokens: CognitoTokenResponse,
   fallbackRefreshToken?: string,
 ): AuthSession => {
-  const payload = decodeJwt<CognitoIdTokenPayload>(tokens.id_token);
+  const payload = decodeJwt<CognitoIdTokenPayload>(tokens.access_token);
 
   const roles = resolveRoles(payload['cognito:groups'] ?? []);
   const provider =
@@ -72,7 +72,7 @@ const buildSessionFromTokens = (
     payload.nickname ?? payload.preferred_username ?? payload.name ?? email.split('@')[0];
 
   return {
-    token: tokens.id_token,
+    token: tokens.access_token,
     idToken: tokens.id_token,
     accessToken: tokens.access_token,
     refreshToken: tokens.refresh_token ?? fallbackRefreshToken,
@@ -112,7 +112,7 @@ export const exchangeAuthorizationCode = async (code: string): Promise<AuthSessi
   const tokens = (await response.json()) as CognitoTokenResponse;
   const session = buildSessionFromTokens(tokens);
 
-  const domainUserId = await fetchDomainUserId(session.sub, tokens.id_token);
+  const domainUserId = await fetchDomainUserId(session.sub, tokens.access_token);
   return { ...session, domainUserId };
 };
 

--- a/src/features/auth/services/fetchDomainUserId.ts
+++ b/src/features/auth/services/fetchDomainUserId.ts
@@ -7,20 +7,17 @@ import apiInstance from '@api/instance';
  * The idToken is temporarily stored in localStorage so the shared api instance
  * interceptor can pick it up, then restored to its previous value afterwards.
  *
- * Returns `undefined` on any error so the session can still be created
- * without a domainUserId (it will be retried on next restore).
+ * Throws if the API call fails so that the login flow is aborted when the
+ * domain user cannot be resolved.
  */
-export const fetchDomainUserId = async (
-  sub: string,
-  idToken: string,
-): Promise<string | undefined> => {
-  try {
-    // Temporarily set the token so the api interceptor sends it as Authorization
-    const previous = typeof window !== 'undefined' ? localStorage.getItem('token') : null;
-    if (typeof window !== 'undefined') {
-      localStorage.setItem('token', idToken);
-    }
+export const fetchDomainUserId = async (sub: string, idToken: string): Promise<string> => {
+  // Temporarily set the token so the api interceptor sends it as Authorization
+  const previous = typeof window !== 'undefined' ? localStorage.getItem('token') : null;
+  if (typeof window !== 'undefined') {
+    localStorage.setItem('token', idToken);
+  }
 
+  try {
     const result = await apiInstance.get<{ data: GetUserBySubResult }>(
       skorifyEndpoints.user.getBySub,
       {
@@ -28,7 +25,11 @@ export const fetchDomainUserId = async (
       },
     );
 
-    // Restore the previous token value
+    return result.data.data.id;
+  } catch (error) {
+    throw new Error('auth.errors.domainUserNotFound', { cause: error });
+  } finally {
+    // Always restore the previous token value
     if (typeof window !== 'undefined') {
       if (previous !== null) {
         localStorage.setItem('token', previous);
@@ -36,9 +37,5 @@ export const fetchDomainUserId = async (
         localStorage.removeItem('token');
       }
     }
-
-    return result.data.data.id;
-  } catch {
-    return undefined;
   }
 };

--- a/src/i18n/messages/en.json
+++ b/src/i18n/messages/en.json
@@ -165,6 +165,7 @@
       "tooManyRequests": "Too many requests. Wait a moment and try again.",
       "genericError": "The operation could not be completed. Please try again.",
       "oauthExchangeFailed": "Could not complete Google sign-in",
+      "domainUserNotFound": "Could not verify your account. Please try again.",
       "nicknameMin": "At least 3 characters",
       "nicknameMax": "At most 24 characters",
       "nicknameFormat": "Only letters, numbers, dot, dash and underscore",

--- a/src/i18n/messages/es.json
+++ b/src/i18n/messages/es.json
@@ -165,6 +165,7 @@
       "tooManyRequests": "Demasiadas solicitudes. Espera un momento e intenta de nuevo.",
       "genericError": "No se pudo completar la operación. Intenta nuevamente.",
       "oauthExchangeFailed": "No se pudo completar el inicio de sesión con Google",
+      "domainUserNotFound": "No se pudo verificar tu cuenta. Intenta nuevamente.",
       "nicknameMin": "Mínimo 3 caracteres",
       "nicknameMax": "Máximo 24 caracteres",
       "nicknameFormat": "Solo letras, números, guion y punto",


### PR DESCRIPTION
- Fixed incorrect token type (`id_token` → `access_token`) in session and auth flow.
- Updated `fetchDomainUserId` to throw errors for unresolved domain users.
- Added new translation keys for "domain user not found" in English and Spanish.