### PR TITLE
fix(auth): correct token type from `access_token` to `id_token`

### DIFF
--- a/src/features/auth/lib/oauth.ts
+++ b/src/features/auth/lib/oauth.ts
@@ -61,7 +61,7 @@ const buildSessionFromTokens = (
   tokens: CognitoTokenResponse,
   fallbackRefreshToken?: string,
 ): AuthSession => {
-  const payload = decodeJwt<CognitoIdTokenPayload>(tokens.access_token);
+  const payload = decodeJwt<CognitoIdTokenPayload>(tokens.id_token);
 
   const roles = resolveRoles(payload['cognito:groups'] ?? []);
   const provider =


### PR DESCRIPTION
fix(auth): correct token type from `access_token` to `id_token` in session decoding